### PR TITLE
WIP EstimOptions struct

### DIFF
--- a/example/run_Emydura_macquarii.jl
+++ b/example/run_Emydura_macquarii.jl
@@ -13,6 +13,15 @@ end
 par_model = Model(par) # create a 'Model' out of the Pars struct
 data_pets = mydata_pets(pets, examplepath)
 
+# EstimOptions to replace the globals set by `estim_options` below
+options = DEBtool_J.EstimOptions(;
+    max_step_number = 5e2,
+    max_fun_evals = 5e3,
+    pars_init_method = 2, 
+    results_output = 3, 
+    method = :nm
+) 
+
 #check_my_pet(pets); 
 estim_options("default");
 estim_options("max_step_number", 5e2);
@@ -23,4 +32,4 @@ estim_options("results_output", 3);
 estim_options("method", "nm");
 
 # currently takes 55 seconds to do 500 steps, matlab takes just under 40
-estim_pars(pets, par_model, metapar, data)
+estim_pars(options, pets, par_model, metapar, data)

--- a/src/lib/pet/estim_options.jl
+++ b/src/lib/pet/estim_options.jl
@@ -842,3 +842,156 @@ function estim_options(key::String, val)
         )
     end
 end
+
+struct EstimOptions{F}
+   method::Symbol
+   lossfunction::Symbol
+   filter::Bool
+   pars_init_method::Int
+   results_output::Int
+   max_fun_evals::Float64
+   report::Bool
+   max_step_number::Int
+   tol_simplex::Float64
+   tol_fun::Float64
+   simplex_size::Float64
+   search_method::Symbol
+   num_results::Int
+   gen_factor::Float64
+   factor_type::Symbol
+   bounds_from_ind::Int
+   max_calibration_time::Int
+   num_runs::Int
+   add_initial::Bool
+   refine_best::Bool
+   verbose::Bool
+   verbose_options::Int
+   random_seeds::Vector{Int}
+   seed_index::Int
+   ranges::Union{Float64,Nothing}
+   mat_file::Union{Float64,Nothing}
+   results_display::Symbol
+   results_filename::String
+   save_results::Bool
+   sigma_share::Float64
+   rng::MersenneTwister
+end
+
+function EstimOptions(;
+    lossfunction = :sb,
+    filter = true,
+    pars_init_method = 2,
+    results_output = 3,
+    method = :nm,
+    max_fun_evals = 1e4,
+    report = true,
+    max_step_number = 500,
+    tol_simplex = 1e-4,
+    tol_fun = 1e-4,
+    simplex_size = 0.05,
+    # for mmea method (taken from calibration_options)
+    search_method = :mm_shade, # Use mm_shade: Success-History based Adaptive Differential Evolution
+    num_results = 50,   # The size for the multimodal algorithm's population.
+    # If not defined then sets the values recommended by the author,
+    # which are 100 for mm_shade ('mm_shade') and 18 * problem size for L-mm_shade.
+    gen_factor = 0.5,    # Percentage bounds for individual
+    # initialization. (e.g. A value of 0.9 means that, for a parameter value of 1,
+    # the range for generation is [(1 - 0.9) * 1, 1 * (1 + 0.9)] so
+    # the new parameter value will be a random between [0.1, 1.9]
+    factor_type = :mult, # The kind of factor to be applied when generatin individuals
+    #('mult' is multiplicative (Default) | 'add' if
+    # additive);
+    bounds_from_ind = 1, # This options selects from where the parameters for the initial population of individuals are taken.
+    # If the value is equal to 1 the parameters are generated from the data initial values
+    # if is 0 then the parameters are generated from the pseudo data values.
+    add_initial = false,     # If to add an invidivual taken from initial data into first population.                     # (only if it the 'add_initial' option is activated)
+    refine_best = false,     # If a local search is applied to the best individual found.
+    max_calibration_time = 30, # The maximum calibration time calibration process.
+    num_runs = 5, # The number of runs to perform.
+    verbose = false,  # If to print some information while the calibration process is running.
+    verbose_options = 5, # The number of solutions to show from the  set of optimal solutions found by the  algorithm through the calibration process.
+    random_seeds = [
+        2147483647,
+        2874923758,
+        1284092845,  # The values of the seed used to
+        2783758913,
+        3287594328,
+        2328947617,  # generate random values (each one is used in a
+        1217489374,
+        1815931031,
+        3278479237,  # single run of the algorithm).
+        3342427357,
+        223758927,
+        3891375891,
+        1781589371,
+        1134872397,
+        2784732823,
+        2183647447,
+        24923758,
+        122845,
+        2783784093,
+        394328,
+        2328757617,
+        12174974,
+        18593131,
+        3287237,
+        33442757,
+        2235827,
+        3837891,
+        17159371,
+        34211397,
+        2842823,
+    ],
+    seed_index = 1, # index for seeds for random number generator
+    ranges = nothing, #struct(); # The range struct is empty by default.
+    results_display = :Basic, # The results output style.
+    results_filename = "Default",
+    save_results = false, # If results output are saved.
+    mat_file = "",
+    sigma_share = 0.1,
+)
+    rng = MersenneTwister(random_seeds[seed_index]), # initialize the number generator is with a seed, to be updated for each run of the calibration method.
+
+    rd = (:Basic, :Best, :Set, :Complete)
+    results_display in rd || throw(ArgumentError("results_display must be one of $rd"))
+
+    m = (:no, :nm, :mmea)
+    method in m || throw(ArgumentError("method must be one of $m"))
+    
+    method == "mmea" && !filter && @warn "estim_options: use a filter with method `:mmea`"
+    0 <= sigmshare <= 1 || throw(ArgumentError("sigma_share must be between 0 and 1"))
+
+    return EstimOptions(
+        method,
+        lossfunction,
+        filter,
+        pars_init_method,
+        results_output,
+        max_fun_evals,
+        report,
+        max_step_number,
+        tol_simplex,
+        tol_fun,
+        simplex_size,
+        search_method,
+        num_results,
+        gen_factor,
+        factor_type,
+        bounds_from_ind,
+        max_calibration_time,
+        num_runs,
+        add_initial,
+        refine_best,
+        verbose,
+        verbose_options,
+        random_seeds,
+        seed_index,
+        ranges,
+        mat_file,
+        results_display,
+        results_filename,
+        save_results,
+        sigma_share,
+        rng,
+    )
+end

--- a/src/lib/pet/estim_pars.jl
+++ b/src/lib/pet/estim_pars.jl
@@ -3,7 +3,7 @@
 
 ##
 #function estim_pars(pets, pars_init_method, method, filter, covRules)
-function estim_pars(pets, par_model, metaPar, mydata_pets)
+function estim_pars(options, pets, par_model, metaPar, mydata_pets)
 
     # created 2015/02/10 by Goncalo Marques
     # modified 2015/02/10 by Bas Kooijman, 


### PR DESCRIPTION
This PR adds a struct for `estim_options` instead of a collection of globable variables. This should help performance and make the code easier to follow and test.

@mkre we can also write a `show` method for it to print out all the values, so we don't need all those print statements in the original code.

(of course I need to actually go through and change all the functions to use this...)