### PR TITLE
format with JuliaFormatter to default style

### DIFF
--- a/docs/pars_init_Emydura_macquarii_ModelParametersStyle.jl
+++ b/docs/pars_init_Emydura_macquarii_ModelParametersStyle.jl
@@ -1,233 +1,95 @@
 Base.@kwdef struct Par{T,Z,L,K,V,PV,PS,R,EV,E,RR,S,D,DM,F,EM,N}
     # reference parameter (not to be changed) 
-    T_ref::T =
-        Param(20.0 + 273.15, units = u"K", free = (0), label = "Reference Temperature")
+    T_ref::T = Param(20.0 + 273.15, units=u"K", free=(0), label="Reference Temperature")
 
     # core primary parameters 
-    z::Z = Param(13.2002, units = u"cm", free = (0), label = "zoom factor")
-    F_m::L = Param(
-        6.5,
-        units = u"l/d/cm^2",
-        free = (0),
-        label = "{F_m}, max spec searching rate",
-    )
-    kap_X::K = Param(
-        0.8,
-        units = nothing,
-        free = (0),
-        label = "digestion efficiency of food to reserve",
-    )
-    kap_P::K = Param(
-        0.1,
-        units = nothing,
-        free = (0),
-        label = "faecation efficiency of food to faeces",
-    )
-    v::V = Param(0.060464, units = u"cm/d", free = (0), label = "energy conductance")
-    kap::K =
-        Param(0.7362, units = nothing, free = (0), label = "allocation fraction to soma")
-    kap_R::K = Param(0.95, units = nothing, free = (0), label = "reproduction efficiency")
-    p_M::PV = Param(
-        16.4025,
-        units = u"J/d/cm^3",
-        free = (0),
-        label = "[p_M], vol-spec somatic maint",
-    )
-    p_T::PS = Param(
-        0.0,
-        units = u"J/d/cm^2",
-        free = (0),
-        label = "{p_T}, surf-spec somatic maint",
-    )
-    k_J::R = Param(
-        0.00060219,
-        units = u"1/d",
-        free = (0),
-        label = "maturity maint rate coefficient",
-    )
-    E_G::EV = Param(
-        7857.8605,
-        units = u"J/cm^3",
-        free = (0),
-        label = "[E_G], spec cost for structure",
-    )
-    E_Hb::E = Param(1.366e+04, units = u"J", free = (0), label = "maturity at birth")
-    E_Hp::E = Param(1.168e+07, units = u"J", free = (0), label = "maturity at puberty")
-    h_a::RR =
-        Param(1.211e-09, units = u"1/d^2", free = (0), label = "Weibull aging acceleration")
-    s_G::S =
-        Param(0.0001, units = nothing, free = (0), label = "Gompertz stress coefficient")
+    z::Z = Param(13.2002, units=u"cm", free=(0), label="zoom factor")
+    F_m::L = Param(6.5, units=u"l/d/cm^2", free=(0), label="{F_m}, max spec searching rate")
+    kap_X::K = Param(0.8, units=nothing, free=(0), label="digestion efficiency of food to reserve")
+    kap_P::K = Param(0.1, units=nothing, free=(0), label="faecation efficiency of food to faeces")
+    v::V = Param(0.060464, units=u"cm/d", free=(0), label="energy conductance")
+    kap::K = Param(0.7362, units=nothing, free=(0), label="allocation fraction to soma")
+    kap_R::K = Param(0.95, units=nothing, free=(0), label="reproduction efficiency")
+    p_M::PV = Param(16.4025, units=u"J/d/cm^3", free=(0), label="[p_M], vol-spec somatic maint")
+    p_T::PS = Param(0.0, units=u"J/d/cm^2", free=(0), label="{p_T}, surf-spec somatic maint")
+    k_J::R = Param(0.00060219, units=u"1/d", free=(0), label="maturity maint rate coefficient")
+    E_G::EV = Param(7857.8605, units=u"J/cm^3", free=(0), label="[E_G], spec cost for structure")
+    E_Hb::E = Param(1.366e+04, units=u"J", free=(0), label="maturity at birth")
+    E_Hp::E = Param(1.168e+07, units=u"J", free=(0), label="maturity at puberty")
+    h_a::RR = Param(1.211e-09, units=u"1/d^2", free=(0), label="Weibull aging acceleration")
+    s_G::S = Param(0.0001, units=nothing, free=(0), label="Gompertz stress coefficient")
 
     # other parameters 
-    T_A::T = Param(8000.0, units = u"K", free = (0), label = "Arrhenius temperature")
-    T_AL::T = Param(50000.0, units = u"K", free = (0), label = "low temp boundary")
-    T_AH::T = Param(50000.0, units = u"K", free = (0), label = "high temp boundary")
-    T_L::T =
-        Param(0 + 273.15, units = u"K", free = (0), label = "low Arrhenius temperature")
-    T_H::T =
-        Param(54.5 + 273.15, units = u"K", free = (0), label = "high Arrhenius temperature")
-    del_M::DM = Param(0.61719, units = nothing, free = (0), label = "shape coefficient")
-    f::F = Param(
-        1.0,
-        units = nothing,
-        free = (0),
-        label = "scaled functional response for 0-var data",
-    )
-    E_Hpm::E =
-        Param(4.711e+06, units = u"J", free = (0), label = "maturity at puberty for male")
-    z_m::Z = Param(13.2002, units = u"cm", free = (0), label = "zoom factor for male")
+    T_A::T = Param(8000.0, units=u"K", free=(0), label="Arrhenius temperature")
+    T_AL::T = Param(50000.0, units=u"K", free=(0), label="low temp boundary")
+    T_AH::T = Param(50000.0, units=u"K", free=(0), label="high temp boundary")
+    T_L::T = Param(0 + 273.15, units=u"K", free=(0), label="low Arrhenius temperature")
+    T_H::T = Param(54.5 + 273.15, units=u"K", free=(0), label="high Arrhenius temperature")
+    del_M::DM = Param(0.61719, units=nothing, free=(0), label="shape coefficient")
+    f::F = Param(1.0, units=nothing, free=(0), label="scaled functional response for 0-var data")
+    E_Hpm::E = Param(4.711e+06, units=u"J", free=(0), label="maturity at puberty for male")
+    z_m::Z = Param(13.2002, units=u"cm", free=(0), label="zoom factor for male")
 
     # chemical parameters
     # specific densities; multiply free by d_V to convert to vector if necessary
-    d_X::D = Param(0.3, units = u"g/cm^3", free = (0), label = "specific density of food")
-    d_V::D =
-        Param(0.3, units = u"g/cm^3", free = (0), label = "specific density of structure")
-    d_E::D =
-        Param(0.3, units = u"g/cm^3", free = (0), label = "specific density of reserve")
-    d_P::D = Param(0.3, units = u"g/cm^3", free = (0), label = "specific density of faeces")
+    d_X::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of food")
+    d_V::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of structure")
+    d_E::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of reserve")
+    d_P::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of faeces")
 
     # chemical potentials from Kooy2010 Tab 4.2
-    mu_X::EM =
-        Param(525000.0, units = u"J/ mol", free = (0), label = "chemical potential of food")
-    mu_V::EM = Param(
-        500000.0,
-        units = u"J/ mol",
-        free = (0),
-        label = "chemical potential of structure",
-    )
-    mu_E::EM = Param(
-        550000.0,
-        units = u"J/ mol",
-        free = (0),
-        label = "chemical potential of reserve",
-    )
-    mu_P::EM = Param(
-        480000.0,
-        units = u"J/ mol",
-        free = (0),
-        label = "chemical potential of faeces",
-    )
+    mu_X::EM = Param(525000.0, units=u"J/ mol", free=(0), label="chemical potential of food")
+    mu_V::EM = Param(500000.0, units=u"J/ mol", free=(0), label="chemical potential of structure")
+    mu_E::EM = Param(550000.0, units=u"J/ mol", free=(0), label="chemical potential of reserve")
+    mu_P::EM = Param(480000.0, units=u"J/ mol", free=(0), label="chemical potential of faeces")
 
     # chemical potential of minerals
-    mu_C::EM =
-        Param(0.0, units = u"J/ mol", free = (0), label = "chemical potential of CO2")
-    mu_H::EM =
-        Param(0.0, units = u"J/ mol", free = (0), label = "chemical potential of H2O")
-    mu_O::EM = Param(0.0, units = u"J/ mol", free = (0), label = "chemical potential of O2")
-    mu_N::EM = Param(
-        4880.0,
-        units = u"J/ mol",
-        free = (0),
-        label = "chemical potential of N-waste",
-    )
+    mu_C::EM = Param(0.0, units=u"J/ mol", free=(0), label="chemical potential of CO2")
+    mu_H::EM = Param(0.0, units=u"J/ mol", free=(0), label="chemical potential of H2O")
+    mu_O::EM = Param(0.0, units=u"J/ mol", free=(0), label="chemical potential of O2")
+    mu_N::EM = Param(4880.0, units=u"J/ mol", free=(0), label="chemical potential of N-waste")
 
     # chemical indices for water-free organics from Kooy2010 Fig 4.15 (excluding contributions of H and O atoms from water)
     # food
-    n_CX::N =
-        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in food") # C/C = 1 by definition
-    n_HX::N =
-        Param(1.8, units = nothing, free = (0), label = "chem. index of hydrogen in food")
-    n_OX::N =
-        Param(0.5, units = nothing, free = (0), label = "chem. index of oxygen in food")
-    n_NX::N =
-        Param(0.15, units = nothing, free = (0), label = "chem. index of nitrogen in food")
+    n_CX::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in food") # C/C = 1 by definition
+    n_HX::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in food")
+    n_OX::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in food")
+    n_NX::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in food")
     # structure
-    n_CV::N = Param(
-        1.0,
-        units = nothing,
-        free = (0),
-        label = "chem. index of carbon in structure",
-    ) # n_CV = 1 by definition
-    n_HV::N = Param(
-        1.8,
-        units = nothing,
-        free = (0),
-        label = "chem. index of hydrogen in structure",
-    )
-    n_OV::N = Param(
-        0.5,
-        units = nothing,
-        free = (0),
-        label = "chem. index of oxygen in structure",
-    )
-    n_NV::N = Param(
-        0.15,
-        units = nothing,
-        free = (0),
-        label = "chem. index of nitrogen in structure",
-    )
+    n_CV::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in structure") # n_CV = 1 by definition
+    n_HV::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in structure")
+    n_OV::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in structure")
+    n_NV::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in structure")
     # reserve
-    n_CE::N =
-        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in reserve")   # n_CE = 1 by definition
-    n_HE::N = Param(
-        1.8,
-        units = nothing,
-        free = (0),
-        label = "chem. index of hydrogen in reserve",
-    )
-    n_OE::N =
-        Param(0.5, units = nothing, free = (0), label = "chem. index of oxygen in reserve")
-    n_NE::N = Param(
-        0.15,
-        units = nothing,
-        free = (0),
-        label = "chem. index of nitrogen in reserve",
-    )
+    n_CE::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in reserve")   # n_CE = 1 by definition
+    n_HE::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in reserve")
+    n_OE::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in reserve")
+    n_NE::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in reserve")
     # faeces
-    n_CP::N =
-        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in faeces")    # n_CP = 1 by definition
-    n_HP::N =
-        Param(1.8, units = nothing, free = (0), label = "chem. index of hydrogen in faeces")
-    n_OP::N =
-        Param(0.5, units = nothing, free = (0), label = "chem. index of oxygen in faeces")
-    n_NP::N = Param(
-        0.15,
-        units = nothing,
-        free = (0),
-        label = "chem. index of nitrogen in faeces",
-    )
+    n_CP::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in faeces")    # n_CP = 1 by definition
+    n_HP::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in faeces")
+    n_OP::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in faeces")
+    n_NP::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in faeces")
 
     # chemical indices for minerals from Kooy2010 
     # CO2 
-    n_CC::N =
-        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in CO2")
-    n_HC::N =
-        Param(0.0, units = nothing, free = (0), label = "chem. index of hydrogen in CO2")
-    n_OC::N =
-        Param(2.0, units = nothing, free = (0), label = "chem. index of oxygen in CO2")
-    n_NC::N =
-        Param(0.0, units = nothing, free = (0), label = "chem. index of nitrogen in CO2")
+    n_CC::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in CO2")
+    n_HC::N = Param(0.0, units=nothing, free=(0), label="chem. index of hydrogen in CO2")
+    n_OC::N = Param(2.0, units=nothing, free=(0), label="chem. index of oxygen in CO2")
+    n_NC::N = Param(0.0, units=nothing, free=(0), label="chem. index of nitrogen in CO2")
     # H2O
-    n_CH::N =
-        Param(0.0, units = nothing, free = (0), label = "chem. index of carbon in H2O")
-    n_HH::N =
-        Param(2.0, units = nothing, free = (0), label = "chem. index of hydrogen in H2O")
-    n_OH::N =
-        Param(1.0, units = nothing, free = (0), label = "chem. index of oxygen in H2O")
-    n_NH::N =
-        Param(0.0, units = nothing, free = (0), label = "chem. index of nitrogen in H2O")
+    n_CH::N = Param(0.0, units=nothing, free=(0), label="chem. index of carbon in H2O")
+    n_HH::N = Param(2.0, units=nothing, free=(0), label="chem. index of hydrogen in H2O")
+    n_OH::N = Param(1.0, units=nothing, free=(0), label="chem. index of oxygen in H2O")
+    n_NH::N = Param(0.0, units=nothing, free=(0), label="chem. index of nitrogen in H2O")
     # O2
-    n_CO::N = Param(0.0, units = nothing, free = (0), label = "chem. index of carbon in O2")
-    n_HO::N =
-        Param(0.0, units = nothing, free = (0), label = "chem. index of hydrogen in O2")
-    n_OO::N = Param(2.0, units = nothing, free = (0), label = "chem. index of oxygen in O2")
-    n_NO::N =
-        Param(0.0, units = nothing, free = (0), label = "chem. index of nitrogen in O2")
+    n_CO::N = Param(0.0, units=nothing, free=(0), label="chem. index of carbon in O2")
+    n_HO::N = Param(0.0, units=nothing, free=(0), label="chem. index of hydrogen in O2")
+    n_OO::N = Param(2.0, units=nothing, free=(0), label="chem. index of oxygen in O2")
+    n_NO::N = Param(0.0, units=nothing, free=(0), label="chem. index of nitrogen in O2")
     # N-waste; multiply free by par to convert to vector if necessary
-    n_CN::N =
-        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in N-waste")   # n_CN = 0 or 1 by definition
-    n_HN::N = Param(
-        0.8,
-        units = nothing,
-        free = (0),
-        label = "chem. index of hydrogen in N-waste",
-    )
-    n_ON::N =
-        Param(0.6, units = nothing, free = (0), label = "chem. index of oxygen in N-waste")
-    n_NN::N = Param(
-        0.8,
-        units = nothing,
-        free = (0),
-        label = "chem. index of nitrogen in N-waste",
-    )
+    n_CN::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in N-waste")   # n_CN = 0 or 1 by definition
+    n_HN::N = Param(0.8, units=nothing, free=(0), label="chem. index of hydrogen in N-waste")
+    n_ON::N = Param(0.6, units=nothing, free=(0), label="chem. index of oxygen in N-waste")
+    n_NN::N = Param(0.8, units=nothing, free=(0), label="chem. index of nitrogen in N-waste")
 end

--- a/docs/pars_init_Emydura_macquarii_ModelParametersStyle.jl
+++ b/docs/pars_init_Emydura_macquarii_ModelParametersStyle.jl
@@ -1,95 +1,233 @@
 Base.@kwdef struct Par{T,Z,L,K,V,PV,PS,R,EV,E,RR,S,D,DM,F,EM,N}
     # reference parameter (not to be changed) 
-    T_ref::T = Param(20.0 + 273.15, units=u"K", free=(0), label="Reference Temperature")
+    T_ref::T =
+        Param(20.0 + 273.15, units = u"K", free = (0), label = "Reference Temperature")
 
     # core primary parameters 
-    z::Z = Param(13.2002, units=u"cm", free=(0), label="zoom factor")
-    F_m::L = Param(6.5, units=u"l/d/cm^2", free=(0), label="{F_m}, max spec searching rate")
-    kap_X::K = Param(0.8, units=nothing, free=(0), label="digestion efficiency of food to reserve")
-    kap_P::K = Param(0.1, units=nothing, free=(0), label="faecation efficiency of food to faeces")
-    v::V = Param(0.060464, units=u"cm/d", free=(0), label="energy conductance")
-    kap::K = Param(0.7362, units=nothing, free=(0), label="allocation fraction to soma")
-    kap_R::K = Param(0.95, units=nothing, free=(0), label="reproduction efficiency")
-    p_M::PV = Param(16.4025, units=u"J/d/cm^3", free=(0), label="[p_M], vol-spec somatic maint")
-    p_T::PS = Param(0.0, units=u"J/d/cm^2", free=(0), label="{p_T}, surf-spec somatic maint")
-    k_J::R = Param(0.00060219, units=u"1/d", free=(0), label="maturity maint rate coefficient")
-    E_G::EV = Param(7857.8605, units=u"J/cm^3", free=(0), label="[E_G], spec cost for structure")
-    E_Hb::E = Param(1.366e+04, units=u"J", free=(0), label="maturity at birth")
-    E_Hp::E = Param(1.168e+07, units=u"J", free=(0), label="maturity at puberty")
-    h_a::RR = Param(1.211e-09, units=u"1/d^2", free=(0), label="Weibull aging acceleration")
-    s_G::S = Param(0.0001, units=nothing, free=(0), label="Gompertz stress coefficient")
+    z::Z = Param(13.2002, units = u"cm", free = (0), label = "zoom factor")
+    F_m::L = Param(
+        6.5,
+        units = u"l/d/cm^2",
+        free = (0),
+        label = "{F_m}, max spec searching rate",
+    )
+    kap_X::K = Param(
+        0.8,
+        units = nothing,
+        free = (0),
+        label = "digestion efficiency of food to reserve",
+    )
+    kap_P::K = Param(
+        0.1,
+        units = nothing,
+        free = (0),
+        label = "faecation efficiency of food to faeces",
+    )
+    v::V = Param(0.060464, units = u"cm/d", free = (0), label = "energy conductance")
+    kap::K =
+        Param(0.7362, units = nothing, free = (0), label = "allocation fraction to soma")
+    kap_R::K = Param(0.95, units = nothing, free = (0), label = "reproduction efficiency")
+    p_M::PV = Param(
+        16.4025,
+        units = u"J/d/cm^3",
+        free = (0),
+        label = "[p_M], vol-spec somatic maint",
+    )
+    p_T::PS = Param(
+        0.0,
+        units = u"J/d/cm^2",
+        free = (0),
+        label = "{p_T}, surf-spec somatic maint",
+    )
+    k_J::R = Param(
+        0.00060219,
+        units = u"1/d",
+        free = (0),
+        label = "maturity maint rate coefficient",
+    )
+    E_G::EV = Param(
+        7857.8605,
+        units = u"J/cm^3",
+        free = (0),
+        label = "[E_G], spec cost for structure",
+    )
+    E_Hb::E = Param(1.366e+04, units = u"J", free = (0), label = "maturity at birth")
+    E_Hp::E = Param(1.168e+07, units = u"J", free = (0), label = "maturity at puberty")
+    h_a::RR =
+        Param(1.211e-09, units = u"1/d^2", free = (0), label = "Weibull aging acceleration")
+    s_G::S =
+        Param(0.0001, units = nothing, free = (0), label = "Gompertz stress coefficient")
 
     # other parameters 
-    T_A::T = Param(8000.0, units=u"K", free=(0), label="Arrhenius temperature")
-    T_AL::T = Param(50000.0, units=u"K", free=(0), label="low temp boundary")
-    T_AH::T = Param(50000.0, units=u"K", free=(0), label="high temp boundary")
-    T_L::T = Param(0 + 273.15, units=u"K", free=(0), label="low Arrhenius temperature")
-    T_H::T = Param(54.5 + 273.15, units=u"K", free=(0), label="high Arrhenius temperature")
-    del_M::DM = Param(0.61719, units=nothing, free=(0), label="shape coefficient")
-    f::F = Param(1.0, units=nothing, free=(0), label="scaled functional response for 0-var data")
-    E_Hpm::E = Param(4.711e+06, units=u"J", free=(0), label="maturity at puberty for male")
-    z_m::Z = Param(13.2002, units=u"cm", free=(0), label="zoom factor for male")
+    T_A::T = Param(8000.0, units = u"K", free = (0), label = "Arrhenius temperature")
+    T_AL::T = Param(50000.0, units = u"K", free = (0), label = "low temp boundary")
+    T_AH::T = Param(50000.0, units = u"K", free = (0), label = "high temp boundary")
+    T_L::T =
+        Param(0 + 273.15, units = u"K", free = (0), label = "low Arrhenius temperature")
+    T_H::T =
+        Param(54.5 + 273.15, units = u"K", free = (0), label = "high Arrhenius temperature")
+    del_M::DM = Param(0.61719, units = nothing, free = (0), label = "shape coefficient")
+    f::F = Param(
+        1.0,
+        units = nothing,
+        free = (0),
+        label = "scaled functional response for 0-var data",
+    )
+    E_Hpm::E =
+        Param(4.711e+06, units = u"J", free = (0), label = "maturity at puberty for male")
+    z_m::Z = Param(13.2002, units = u"cm", free = (0), label = "zoom factor for male")
 
     # chemical parameters
     # specific densities; multiply free by d_V to convert to vector if necessary
-    d_X::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of food")
-    d_V::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of structure")
-    d_E::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of reserve")
-    d_P::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of faeces")
+    d_X::D = Param(0.3, units = u"g/cm^3", free = (0), label = "specific density of food")
+    d_V::D =
+        Param(0.3, units = u"g/cm^3", free = (0), label = "specific density of structure")
+    d_E::D =
+        Param(0.3, units = u"g/cm^3", free = (0), label = "specific density of reserve")
+    d_P::D = Param(0.3, units = u"g/cm^3", free = (0), label = "specific density of faeces")
 
     # chemical potentials from Kooy2010 Tab 4.2
-    mu_X::EM = Param(525000.0, units=u"J/ mol", free=(0), label="chemical potential of food")
-    mu_V::EM = Param(500000.0, units=u"J/ mol", free=(0), label="chemical potential of structure")
-    mu_E::EM = Param(550000.0, units=u"J/ mol", free=(0), label="chemical potential of reserve")
-    mu_P::EM = Param(480000.0, units=u"J/ mol", free=(0), label="chemical potential of faeces")
+    mu_X::EM =
+        Param(525000.0, units = u"J/ mol", free = (0), label = "chemical potential of food")
+    mu_V::EM = Param(
+        500000.0,
+        units = u"J/ mol",
+        free = (0),
+        label = "chemical potential of structure",
+    )
+    mu_E::EM = Param(
+        550000.0,
+        units = u"J/ mol",
+        free = (0),
+        label = "chemical potential of reserve",
+    )
+    mu_P::EM = Param(
+        480000.0,
+        units = u"J/ mol",
+        free = (0),
+        label = "chemical potential of faeces",
+    )
 
     # chemical potential of minerals
-    mu_C::EM = Param(0.0, units=u"J/ mol", free=(0), label="chemical potential of CO2")
-    mu_H::EM = Param(0.0, units=u"J/ mol", free=(0), label="chemical potential of H2O")
-    mu_O::EM = Param(0.0, units=u"J/ mol", free=(0), label="chemical potential of O2")
-    mu_N::EM = Param(4880.0, units=u"J/ mol", free=(0), label="chemical potential of N-waste")
+    mu_C::EM =
+        Param(0.0, units = u"J/ mol", free = (0), label = "chemical potential of CO2")
+    mu_H::EM =
+        Param(0.0, units = u"J/ mol", free = (0), label = "chemical potential of H2O")
+    mu_O::EM = Param(0.0, units = u"J/ mol", free = (0), label = "chemical potential of O2")
+    mu_N::EM = Param(
+        4880.0,
+        units = u"J/ mol",
+        free = (0),
+        label = "chemical potential of N-waste",
+    )
 
     # chemical indices for water-free organics from Kooy2010 Fig 4.15 (excluding contributions of H and O atoms from water)
     # food
-    n_CX::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in food") # C/C = 1 by definition
-    n_HX::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in food")
-    n_OX::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in food")
-    n_NX::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in food")
+    n_CX::N =
+        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in food") # C/C = 1 by definition
+    n_HX::N =
+        Param(1.8, units = nothing, free = (0), label = "chem. index of hydrogen in food")
+    n_OX::N =
+        Param(0.5, units = nothing, free = (0), label = "chem. index of oxygen in food")
+    n_NX::N =
+        Param(0.15, units = nothing, free = (0), label = "chem. index of nitrogen in food")
     # structure
-    n_CV::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in structure") # n_CV = 1 by definition
-    n_HV::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in structure")
-    n_OV::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in structure")
-    n_NV::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in structure")
+    n_CV::N = Param(
+        1.0,
+        units = nothing,
+        free = (0),
+        label = "chem. index of carbon in structure",
+    ) # n_CV = 1 by definition
+    n_HV::N = Param(
+        1.8,
+        units = nothing,
+        free = (0),
+        label = "chem. index of hydrogen in structure",
+    )
+    n_OV::N = Param(
+        0.5,
+        units = nothing,
+        free = (0),
+        label = "chem. index of oxygen in structure",
+    )
+    n_NV::N = Param(
+        0.15,
+        units = nothing,
+        free = (0),
+        label = "chem. index of nitrogen in structure",
+    )
     # reserve
-    n_CE::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in reserve")   # n_CE = 1 by definition
-    n_HE::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in reserve")
-    n_OE::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in reserve")
-    n_NE::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in reserve")
+    n_CE::N =
+        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in reserve")   # n_CE = 1 by definition
+    n_HE::N = Param(
+        1.8,
+        units = nothing,
+        free = (0),
+        label = "chem. index of hydrogen in reserve",
+    )
+    n_OE::N =
+        Param(0.5, units = nothing, free = (0), label = "chem. index of oxygen in reserve")
+    n_NE::N = Param(
+        0.15,
+        units = nothing,
+        free = (0),
+        label = "chem. index of nitrogen in reserve",
+    )
     # faeces
-    n_CP::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in faeces")    # n_CP = 1 by definition
-    n_HP::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in faeces")
-    n_OP::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in faeces")
-    n_NP::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in faeces")
+    n_CP::N =
+        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in faeces")    # n_CP = 1 by definition
+    n_HP::N =
+        Param(1.8, units = nothing, free = (0), label = "chem. index of hydrogen in faeces")
+    n_OP::N =
+        Param(0.5, units = nothing, free = (0), label = "chem. index of oxygen in faeces")
+    n_NP::N = Param(
+        0.15,
+        units = nothing,
+        free = (0),
+        label = "chem. index of nitrogen in faeces",
+    )
 
     # chemical indices for minerals from Kooy2010 
     # CO2 
-    n_CC::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in CO2")
-    n_HC::N = Param(0.0, units=nothing, free=(0), label="chem. index of hydrogen in CO2")
-    n_OC::N = Param(2.0, units=nothing, free=(0), label="chem. index of oxygen in CO2")
-    n_NC::N = Param(0.0, units=nothing, free=(0), label="chem. index of nitrogen in CO2")
+    n_CC::N =
+        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in CO2")
+    n_HC::N =
+        Param(0.0, units = nothing, free = (0), label = "chem. index of hydrogen in CO2")
+    n_OC::N =
+        Param(2.0, units = nothing, free = (0), label = "chem. index of oxygen in CO2")
+    n_NC::N =
+        Param(0.0, units = nothing, free = (0), label = "chem. index of nitrogen in CO2")
     # H2O
-    n_CH::N = Param(0.0, units=nothing, free=(0), label="chem. index of carbon in H2O")
-    n_HH::N = Param(2.0, units=nothing, free=(0), label="chem. index of hydrogen in H2O")
-    n_OH::N = Param(1.0, units=nothing, free=(0), label="chem. index of oxygen in H2O")
-    n_NH::N = Param(0.0, units=nothing, free=(0), label="chem. index of nitrogen in H2O")
+    n_CH::N =
+        Param(0.0, units = nothing, free = (0), label = "chem. index of carbon in H2O")
+    n_HH::N =
+        Param(2.0, units = nothing, free = (0), label = "chem. index of hydrogen in H2O")
+    n_OH::N =
+        Param(1.0, units = nothing, free = (0), label = "chem. index of oxygen in H2O")
+    n_NH::N =
+        Param(0.0, units = nothing, free = (0), label = "chem. index of nitrogen in H2O")
     # O2
-    n_CO::N = Param(0.0, units=nothing, free=(0), label="chem. index of carbon in O2")
-    n_HO::N = Param(0.0, units=nothing, free=(0), label="chem. index of hydrogen in O2")
-    n_OO::N = Param(2.0, units=nothing, free=(0), label="chem. index of oxygen in O2")
-    n_NO::N = Param(0.0, units=nothing, free=(0), label="chem. index of nitrogen in O2")
+    n_CO::N = Param(0.0, units = nothing, free = (0), label = "chem. index of carbon in O2")
+    n_HO::N =
+        Param(0.0, units = nothing, free = (0), label = "chem. index of hydrogen in O2")
+    n_OO::N = Param(2.0, units = nothing, free = (0), label = "chem. index of oxygen in O2")
+    n_NO::N =
+        Param(0.0, units = nothing, free = (0), label = "chem. index of nitrogen in O2")
     # N-waste; multiply free by par to convert to vector if necessary
-    n_CN::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in N-waste")   # n_CN = 0 or 1 by definition
-    n_HN::N = Param(0.8, units=nothing, free=(0), label="chem. index of hydrogen in N-waste")
-    n_ON::N = Param(0.6, units=nothing, free=(0), label="chem. index of oxygen in N-waste")
-    n_NN::N = Param(0.8, units=nothing, free=(0), label="chem. index of nitrogen in N-waste")
+    n_CN::N =
+        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in N-waste")   # n_CN = 0 or 1 by definition
+    n_HN::N = Param(
+        0.8,
+        units = nothing,
+        free = (0),
+        label = "chem. index of hydrogen in N-waste",
+    )
+    n_ON::N =
+        Param(0.6, units = nothing, free = (0), label = "chem. index of oxygen in N-waste")
+    n_NN::N = Param(
+        0.8,
+        units = nothing,
+        free = (0),
+        label = "chem. index of nitrogen in N-waste",
+    )
 end

--- a/example/mydata_Emydura_macquarii.jl
+++ b/example/mydata_Emydura_macquarii.jl
@@ -11,9 +11,10 @@
     family::String = "Chelidae"
     species::String = "Emydura_macquarii"
     species_en::String = "Murray River turtle"
-    ecoCode
+    ecoCode::Any
     T_typical::T = Unitful.K(22Unitful.°C)
-    data_0::Vector{String} = ["ab_T", "ap", "am", "Lb", "Lp", "Li", "Wwb", "Wwp", "Wwi", "Ri"]
+    data_0::Vector{String} =
+        ["ab_T", "ap", "am", "Lb", "Lp", "Li", "Wwb", "Wwp", "Wwi", "Ri"]
     data_1::Vector{String} = ["t-L"]
     COMPLETE::Float32 = 2.5
     author::String = "Bas Kooijman"
@@ -23,11 +24,11 @@
     curator::String = "Starrlight Augustine"
     email_cur::String = "starrlight@akvaplan.niva.no"
     date_acc::Vector{Int32} = [2017, 10, 09]
-    links
-    facts
-    discussion
-    bibkey
-    biblist
+    links::Any
+    facts::Any
+    discussion::Any
+    bibkey::Any
+    biblist::Any
 end
 
 @with_kw mutable struct ecoCode_struct
@@ -45,9 +46,9 @@ ecoCode = ecoCode_struct()
 @with_kw mutable struct data_struct{A,L,W,R}
     ab::A = 78.0d
     ab30::A = 48.0d
-    tp::A = 10.0*365.0d
-    tpm::A = 5.5*365.0d
-    am::A = 20.9*365.0d
+    tp::A = 10.0 * 365.0d
+    tpm::A = 5.5 * 365.0d
+    am::A = 20.9 * 365.0d
     Lb::L = 2.7cm
     Lp::L = 18.7cm
     Lpm::L = 14.7cm
@@ -58,36 +59,38 @@ ecoCode = ecoCode_struct()
     Wwpm::W = 1297.0g
     Wwi::W = 4000.0g
     Wwim::W = 3673.0g
-    Ri::R = 36.0/365.0d
-    tL
-    psd
+    Ri::R = 36.0 / 365.0d
+    tL::Any
+    psd::Any
 end
-tL1 = [0.981	6.876
-            0.981	7.090
-            1.956	8.369
-            1.956	8.689
-            1.957	9.115
-            1.957	9.435
-            1.957	9.808
-            1.958	10.075
-            1.958	10.235
-            1.983	10.661
-            2.833	11.141
-            2.908	11.354
-            2.931	9.701
-            2.932	10.768
-            2.984	12.420
-            3.008	11.674
-            3.833	13.220
-            3.834	13.326
-            3.834	13.646
-            3.857	12.100
-            3.883	12.420
-            3.883	12.633
-            3.883	12.953
-            3.934	14.072]
-tL_age = tL1[:,1]*365*u"d"
-tL_length = tL1[:,2]*u"cm"
+tL1 = [
+    0.981 6.876
+    0.981 7.090
+    1.956 8.369
+    1.956 8.689
+    1.957 9.115
+    1.957 9.435
+    1.957 9.808
+    1.958 10.075
+    1.958 10.235
+    1.983 10.661
+    2.833 11.141
+    2.908 11.354
+    2.931 9.701
+    2.932 10.768
+    2.984 12.420
+    3.008 11.674
+    3.833 13.220
+    3.834 13.326
+    3.834 13.646
+    3.857 12.100
+    3.883 12.420
+    3.883 12.633
+    3.883 12.953
+    3.934 14.072
+]
+tL_age = tL1[:, 1] * 365 * u"d"
+tL_length = tL1[:, 2] * u"cm"
 tL2 = [tL_age, tL_length]
 data = data_struct(tL = tL2, psd = psdData)
 
@@ -120,7 +123,7 @@ temp = temp_struct()
     Wwim::String = "ultimate wet weight for males"
     Ri::String = "maximum reprod rate"
     tL::Vector{String} = ["time since birth", "carapace length"]
-    psd
+    psd::Any
 end
 label = label_struct(psd = psdLabel)
 
@@ -164,7 +167,7 @@ bibkey = bibkey_struct()
     Wwim::String = "g"
     Ri::String = "#/d"
     tL::Vector{String} = ["time since birth", "carapace length"]
-    psd
+    psd::Any
 end
 units = units_struct(psd = psdUnits)
 
@@ -185,20 +188,23 @@ units = units_struct(psd = psdUnits)
     Wwi::Float64 = 1
     Wwim::Float64 = 1
     Ri::Float64 = 1
-    tL
-    psd
+    tL::Any
+    psd::Any
 end
 nvar = length(tL2)
 N = length(tL2[1])
-weights = weight_struct(tL = ones(N, nvar-1)/ N/ (nvar-1), psd = psdWeight)
+weights = weight_struct(tL = ones(N, nvar - 1) / N / (nvar - 1), psd = psdWeight)
 ## set weights for all real data
 #weights = setweights(data, weights);
 weights.tL = 2 * weights.tL;
 
 ## set pseudodata and respective weights
 # [data, units, label, weights] = addpseudodata(data, units, label, weights);
-weights.psd.k_J = 0; weights.psd.k = 0.1;
-data.psd.k = 0.3; units.psd.k  = "-"; label.psd.k  = "maintenance ratio"; 
+weights.psd.k_J = 0;
+weights.psd.k = 0.1;
+data.psd.k = 0.3;
+units.psd.k = "-";
+label.psd.k = "maintenance ratio";
 
 # Discussion points
 @with_kw mutable struct discussion_struct
@@ -263,43 +269,50 @@ end
 auxData = struct_auxData()
 
 # ## References
-bibkey = "Wiki"; type = "Misc"; bib = 
- "howpublished = {\\url{http://en.wikipedia.org/wiki/Emydura_macquarii}}";
- #metaData.biblist.(bibkey) = ["""@", type, "{", bibkey, ", " bib, "}"";"];
- Wiki = "''@" * type * "{" * bibkey * ", " * join(bib) * "}'';";
+bibkey = "Wiki";
+type = "Misc";
+bib = "howpublished = {\\url{http://en.wikipedia.org/wiki/Emydura_macquarii}}";
+#metaData.biblist.(bibkey) = ["""@", type, "{", bibkey, ", " bib, "}"";"];
+Wiki = "''@" * type * "{" * bibkey * ", " * join(bib) * "}'';";
 
 # #
 bibkey = "Kooy2010"
 type = "Book"
 bib = [ # used in setting of chemical parameters and pseudodata
- "author = {Kooijman, S.A.L.M.}, ", 
- "year = {2010}, ", 
- "title  = {Dynamic Energy Budget theory for metabolic organisation}, ", 
- "publisher = {Cambridge Univ. Press, Cambridge}, ",
- "pages = {Table 4.2 (page 150), 8.1 (page 300)}, ", 
- "howpublished = {\\url{../../../bib/Kooy2010.html}}"]
- Kooy2010 = "''@" * type * "{" * bibkey * ", " * join(bib) * "}'';";
- #Kooy2010 = ["''@" * type * "{" * bibkey * ", " * bib[1] * "}'';"];
+    "author = {Kooijman, S.A.L.M.}, ",
+    "year = {2010}, ",
+    "title  = {Dynamic Energy Budget theory for metabolic organisation}, ",
+    "publisher = {Cambridge Univ. Press, Cambridge}, ",
+    "pages = {Table 4.2 (page 150), 8.1 (page 300)}, ",
+    "howpublished = {\\url{../../../bib/Kooy2010.html}}",
+]
+Kooy2010 = "''@" * type * "{" * bibkey * ", " * join(bib) * "}'';";
+#Kooy2010 = ["''@" * type * "{" * bibkey * ", " * bib[1] * "}'';"];
 # #
-bibkey = "Spen2002"; type = "Article"; bib = [  
- "author = {R.-J. Spencer}, " 
- "year = {2002}, "
- "title = {Growth patterns in two widely distributed freshwater turtles and a comparison of methods used to estimate age}, "
- "journal = {Austr. J. Zool.}, "
- "volume = {50}, "
- "pages = {477--490}"];
- #Spen2002 = ["''@" * type * "{" * bibkey * ", " * bib * "}'';"];
- Spen2002 = "''@" * type * "{" * bibkey * ", " * join(bib) * "}'';";
+bibkey = "Spen2002";
+type = "Article";
+bib = [
+    "author = {R.-J. Spencer}, "
+    "year = {2002}, "
+    "title = {Growth patterns in two widely distributed freshwater turtles and a comparison of methods used to estimate age}, "
+    "journal = {Austr. J. Zool.}, "
+    "volume = {50}, "
+    "pages = {477--490}"
+];
+#Spen2002 = ["''@" * type * "{" * bibkey * ", " * bib * "}'';"];
+Spen2002 = "''@" * type * "{" * bibkey * ", " * join(bib) * "}'';";
 # metaData.biblist.(bibkey) = ["""@", type, "{", bibkey, ", " bib, "}"";"];
 # #
-bibkey = "AnAge"; type = "Misc"; bib =
- "howpublished = {\\url{http://genomics.senescence.info/species/entry.php?species=Emydura_macquarii}}";
- AnAge = "''@" * type * "{" * bibkey * ", " * join(bib) * "}'';";
- #metaData.biblist.(bibkey) = ["""@", type, "{", bibkey, ", " bib, "}"";"];
+bibkey = "AnAge";
+type = "Misc";
+bib = "howpublished = {\\url{http://genomics.senescence.info/species/entry.php?species=Emydura_macquarii}}";
+AnAge = "''@" * type * "{" * bibkey * ", " * join(bib) * "}'';";
+#metaData.biblist.(bibkey) = ["""@", type, "{", bibkey, ", " bib, "}"";"];
 # #
- bibkey = "carettochelys"; type = "Misc"; bib = 
- "howpublished = {\\url{http://www.carettochelys.com/emydura/emydura_mac_mac_3.htm}}";
- carettochelys = "''@" * type * "{" * bibkey * ", " * join(bib) * "}'';";
+bibkey = "carettochelys";
+type = "Misc";
+bib = "howpublished = {\\url{http://www.carettochelys.com/emydura/emydura_mac_mac_3.htm}}";
+carettochelys = "''@" * type * "{" * bibkey * ", " * join(bib) * "}'';";
 # metaData.biblist.(bibkey) = ["""@", type, "{", bibkey, ", " bib, "}"";"];
 
 @with_kw mutable struct biblist_struct
@@ -310,7 +323,14 @@ bibkey = "AnAge"; type = "Misc"; bib =
 end
 biblist = biblist_struct()
 
-metaData = metaData_struct(ecoCode = ecoCode, links = links, facts = facts, discussion = discussion, bibkey = bibkey, biblist = biblist)
+metaData = metaData_struct(
+    ecoCode = ecoCode,
+    links = links,
+    facts = facts,
+    discussion = discussion,
+    bibkey = bibkey,
+    biblist = biblist,
+)
 
 # export(data)
 # export(auxData)

--- a/example/pars_init_Emydura_macquarii.jl
+++ b/example/pars_init_Emydura_macquarii.jl
@@ -1,97 +1,233 @@
 Base.@kwdef struct Par{T,Z,L,K,V,PV,PS,R,EV,E,RR,S,D,DM,F,EM,N}
     # reference parameter (not to be changed) 
-    T_ref::T = Param(20.0 + 273.15, units=u"K", free=(0), label="Reference Temperature")
+    T_ref::T =
+        Param(20.0 + 273.15, units = u"K", free = (0), label = "Reference Temperature")
 
     # core primary parameters 
-    z::N = Param(13.2002, units=nothing, free=(1), label="zoom factor")
-    F_m::L = Param(6.5, units=u"l/d/cm^2", free=(0), label="{F_m}, max spec searching rate")
-    kap_X::K = Param(0.8, units=nothing, free=(0), label="digestion efficiency of food to reserve")
-    kap_P::K = Param(0.1, units=nothing, free=(0), label="faecation efficiency of food to faeces")
-    v::V = Param(0.060464, units=u"cm/d", free=(1), label="energy conductance")
-    kap::K = Param(0.7362, units=nothing, free=(1), label="allocation fraction to soma")
-    kap_R::K = Param(0.95, units=nothing, free=(0), label="reproduction efficiency")
-    p_M::PV = Param(16.4025, units=u"J/d/cm^3", free=(1), label="[p_M], vol-spec somatic maint")
-    p_T::PS = Param(0.0, units=u"J/d/cm^2", free=(0), label="{p_T}, surf-spec somatic maint")
-    k_J::R = Param(0.00060219, units=u"1/d", free=(1), label="maturity maint rate coefficient")
-    E_G::EV = Param(7857.8605, units=u"J/cm^3", free=(1), label="[E_G], spec cost for structure")
-    E_Hb::E = Param(1.366e+04, units=u"J", free=(1), label="maturity at birth")
-    E_Hp::E = Param(1.168e+07, units=u"J", free=(1), label="maturity at puberty")
-    h_a::RR = Param(1.211e-09, units=u"1/d^2", free=(1), label="Weibull aging acceleration")
-    s_G::S = Param(0.0001, units=nothing, free=(0), label="Gompertz stress coefficient")
+    z::N = Param(13.2002, units = nothing, free = (1), label = "zoom factor")
+    F_m::L = Param(
+        6.5,
+        units = u"l/d/cm^2",
+        free = (0),
+        label = "{F_m}, max spec searching rate",
+    )
+    kap_X::K = Param(
+        0.8,
+        units = nothing,
+        free = (0),
+        label = "digestion efficiency of food to reserve",
+    )
+    kap_P::K = Param(
+        0.1,
+        units = nothing,
+        free = (0),
+        label = "faecation efficiency of food to faeces",
+    )
+    v::V = Param(0.060464, units = u"cm/d", free = (1), label = "energy conductance")
+    kap::K =
+        Param(0.7362, units = nothing, free = (1), label = "allocation fraction to soma")
+    kap_R::K = Param(0.95, units = nothing, free = (0), label = "reproduction efficiency")
+    p_M::PV = Param(
+        16.4025,
+        units = u"J/d/cm^3",
+        free = (1),
+        label = "[p_M], vol-spec somatic maint",
+    )
+    p_T::PS = Param(
+        0.0,
+        units = u"J/d/cm^2",
+        free = (0),
+        label = "{p_T}, surf-spec somatic maint",
+    )
+    k_J::R = Param(
+        0.00060219,
+        units = u"1/d",
+        free = (1),
+        label = "maturity maint rate coefficient",
+    )
+    E_G::EV = Param(
+        7857.8605,
+        units = u"J/cm^3",
+        free = (1),
+        label = "[E_G], spec cost for structure",
+    )
+    E_Hb::E = Param(1.366e+04, units = u"J", free = (1), label = "maturity at birth")
+    E_Hp::E = Param(1.168e+07, units = u"J", free = (1), label = "maturity at puberty")
+    h_a::RR =
+        Param(1.211e-09, units = u"1/d^2", free = (1), label = "Weibull aging acceleration")
+    s_G::S =
+        Param(0.0001, units = nothing, free = (0), label = "Gompertz stress coefficient")
 
     # other parameters 
-    E_Hpm::E = Param(4.711e+06, units=u"J", free=(1), label="maturity at puberty for male")
-    T_A::T = Param(8000.0, units=u"K", free=(0), label="Arrhenius temperature")
+    E_Hpm::E =
+        Param(4.711e+06, units = u"J", free = (1), label = "maturity at puberty for male")
+    T_A::T = Param(8000.0, units = u"K", free = (0), label = "Arrhenius temperature")
     #T_AL::T = Param(50000.0, units=u"K", free=(0), label="low temp boundary")
     #T_AH::T = Param(50000.0, units=u"K", free=(0), label="high temp boundary")
     #T_L::T = Param(0 + 273.15, units=u"K", free=(0), label="low Arrhenius temperature")
     #T_H::T = Param(54.5 + 273.15, units=u"K", free=(0), label="high Arrhenius temperature")
-    del_M::DM = Param(0.61719, units=nothing, free=(1), label="shape coefficient")
-    f::F = Param(1.0, units=nothing, free=(0), label="scaled functional response for 0-var data")
-    z_m::Z = Param(13.2002, units=u"cm", free=(1), label="zoom factor for male")
+    del_M::DM = Param(0.61719, units = nothing, free = (1), label = "shape coefficient")
+    f::F = Param(
+        1.0,
+        units = nothing,
+        free = (0),
+        label = "scaled functional response for 0-var data",
+    )
+    z_m::Z = Param(13.2002, units = u"cm", free = (1), label = "zoom factor for male")
 
     # chemical parameters
     # specific densities; multiply free by d_V to convert to vector if necessary
-    d_X::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of food")
-    d_V::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of structure")
-    d_E::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of reserve")
-    d_P::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of faeces")
+    d_X::D = Param(0.3, units = u"g/cm^3", free = (0), label = "specific density of food")
+    d_V::D =
+        Param(0.3, units = u"g/cm^3", free = (0), label = "specific density of structure")
+    d_E::D =
+        Param(0.3, units = u"g/cm^3", free = (0), label = "specific density of reserve")
+    d_P::D = Param(0.3, units = u"g/cm^3", free = (0), label = "specific density of faeces")
 
     # chemical potentials from Kooy2010 Tab 4.2
-    mu_X::EM = Param(525000.0, units=u"J/ mol", free=(0), label="chemical potential of food")
-    mu_V::EM = Param(500000.0, units=u"J/ mol", free=(0), label="chemical potential of structure")
-    mu_E::EM = Param(550000.0, units=u"J/ mol", free=(0), label="chemical potential of reserve")
-    mu_P::EM = Param(480000.0, units=u"J/ mol", free=(0), label="chemical potential of faeces")
+    mu_X::EM =
+        Param(525000.0, units = u"J/ mol", free = (0), label = "chemical potential of food")
+    mu_V::EM = Param(
+        500000.0,
+        units = u"J/ mol",
+        free = (0),
+        label = "chemical potential of structure",
+    )
+    mu_E::EM = Param(
+        550000.0,
+        units = u"J/ mol",
+        free = (0),
+        label = "chemical potential of reserve",
+    )
+    mu_P::EM = Param(
+        480000.0,
+        units = u"J/ mol",
+        free = (0),
+        label = "chemical potential of faeces",
+    )
 
     # chemical potential of minerals
-    mu_C::EM = Param(0.0, units=u"J/ mol", free=(0), label="chemical potential of CO2")
-    mu_H::EM = Param(0.0, units=u"J/ mol", free=(0), label="chemical potential of H2O")
-    mu_O::EM = Param(0.0, units=u"J/ mol", free=(0), label="chemical potential of O2")
-    mu_N::EM = Param(4880.0, units=u"J/ mol", free=(0), label="chemical potential of N-waste")
+    mu_C::EM =
+        Param(0.0, units = u"J/ mol", free = (0), label = "chemical potential of CO2")
+    mu_H::EM =
+        Param(0.0, units = u"J/ mol", free = (0), label = "chemical potential of H2O")
+    mu_O::EM = Param(0.0, units = u"J/ mol", free = (0), label = "chemical potential of O2")
+    mu_N::EM = Param(
+        4880.0,
+        units = u"J/ mol",
+        free = (0),
+        label = "chemical potential of N-waste",
+    )
 
     # chemical indices for water-free organics from Kooy2010 Fig 4.15 (excluding contributions of H and O atoms from water)
     # food
-    n_CX::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in food") # C/C = 1 by definition
-    n_HX::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in food")
-    n_OX::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in food")
-    n_NX::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in food")
+    n_CX::N =
+        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in food") # C/C = 1 by definition
+    n_HX::N =
+        Param(1.8, units = nothing, free = (0), label = "chem. index of hydrogen in food")
+    n_OX::N =
+        Param(0.5, units = nothing, free = (0), label = "chem. index of oxygen in food")
+    n_NX::N =
+        Param(0.15, units = nothing, free = (0), label = "chem. index of nitrogen in food")
     # structure
-    n_CV::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in structure") # n_CV = 1 by definition
-    n_HV::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in structure")
-    n_OV::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in structure")
-    n_NV::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in structure")
+    n_CV::N = Param(
+        1.0,
+        units = nothing,
+        free = (0),
+        label = "chem. index of carbon in structure",
+    ) # n_CV = 1 by definition
+    n_HV::N = Param(
+        1.8,
+        units = nothing,
+        free = (0),
+        label = "chem. index of hydrogen in structure",
+    )
+    n_OV::N = Param(
+        0.5,
+        units = nothing,
+        free = (0),
+        label = "chem. index of oxygen in structure",
+    )
+    n_NV::N = Param(
+        0.15,
+        units = nothing,
+        free = (0),
+        label = "chem. index of nitrogen in structure",
+    )
     # reserve
-    n_CE::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in reserve")   # n_CE = 1 by definition
-    n_HE::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in reserve")
-    n_OE::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in reserve")
-    n_NE::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in reserve")
+    n_CE::N =
+        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in reserve")   # n_CE = 1 by definition
+    n_HE::N = Param(
+        1.8,
+        units = nothing,
+        free = (0),
+        label = "chem. index of hydrogen in reserve",
+    )
+    n_OE::N =
+        Param(0.5, units = nothing, free = (0), label = "chem. index of oxygen in reserve")
+    n_NE::N = Param(
+        0.15,
+        units = nothing,
+        free = (0),
+        label = "chem. index of nitrogen in reserve",
+    )
     # faeces
-    n_CP::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in faeces")    # n_CP = 1 by definition
-    n_HP::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in faeces")
-    n_OP::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in faeces")
-    n_NP::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in faeces")
+    n_CP::N =
+        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in faeces")    # n_CP = 1 by definition
+    n_HP::N =
+        Param(1.8, units = nothing, free = (0), label = "chem. index of hydrogen in faeces")
+    n_OP::N =
+        Param(0.5, units = nothing, free = (0), label = "chem. index of oxygen in faeces")
+    n_NP::N = Param(
+        0.15,
+        units = nothing,
+        free = (0),
+        label = "chem. index of nitrogen in faeces",
+    )
 
     # chemical indices for minerals from Kooy2010 
     # CO2 
-    n_CC::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in CO2")
-    n_HC::N = Param(0.0, units=nothing, free=(0), label="chem. index of hydrogen in CO2")
-    n_OC::N = Param(2.0, units=nothing, free=(0), label="chem. index of oxygen in CO2")
-    n_NC::N = Param(0.0, units=nothing, free=(0), label="chem. index of nitrogen in CO2")
+    n_CC::N =
+        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in CO2")
+    n_HC::N =
+        Param(0.0, units = nothing, free = (0), label = "chem. index of hydrogen in CO2")
+    n_OC::N =
+        Param(2.0, units = nothing, free = (0), label = "chem. index of oxygen in CO2")
+    n_NC::N =
+        Param(0.0, units = nothing, free = (0), label = "chem. index of nitrogen in CO2")
     # H2O
-    n_CH::N = Param(0.0, units=nothing, free=(0), label="chem. index of carbon in H2O")
-    n_HH::N = Param(2.0, units=nothing, free=(0), label="chem. index of hydrogen in H2O")
-    n_OH::N = Param(1.0, units=nothing, free=(0), label="chem. index of oxygen in H2O")
-    n_NH::N = Param(0.0, units=nothing, free=(0), label="chem. index of nitrogen in H2O")
+    n_CH::N =
+        Param(0.0, units = nothing, free = (0), label = "chem. index of carbon in H2O")
+    n_HH::N =
+        Param(2.0, units = nothing, free = (0), label = "chem. index of hydrogen in H2O")
+    n_OH::N =
+        Param(1.0, units = nothing, free = (0), label = "chem. index of oxygen in H2O")
+    n_NH::N =
+        Param(0.0, units = nothing, free = (0), label = "chem. index of nitrogen in H2O")
     # O2
-    n_CO::N = Param(0.0, units=nothing, free=(0), label="chem. index of carbon in O2")
-    n_HO::N = Param(0.0, units=nothing, free=(0), label="chem. index of hydrogen in O2")
-    n_OO::N = Param(2.0, units=nothing, free=(0), label="chem. index of oxygen in O2")
-    n_NO::N = Param(0.0, units=nothing, free=(0), label="chem. index of nitrogen in O2")
+    n_CO::N = Param(0.0, units = nothing, free = (0), label = "chem. index of carbon in O2")
+    n_HO::N =
+        Param(0.0, units = nothing, free = (0), label = "chem. index of hydrogen in O2")
+    n_OO::N = Param(2.0, units = nothing, free = (0), label = "chem. index of oxygen in O2")
+    n_NO::N =
+        Param(0.0, units = nothing, free = (0), label = "chem. index of nitrogen in O2")
     # N-waste; multiply free by par to convert to vector if necessary
-    n_CN::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in N-waste")   # n_CN = 0 or 1 by definition
-    n_HN::N = Param(0.8, units=nothing, free=(0), label="chem. index of hydrogen in N-waste")
-    n_ON::N = Param(0.6, units=nothing, free=(0), label="chem. index of oxygen in N-waste")
-    n_NN::N = Param(0.8, units=nothing, free=(0), label="chem. index of nitrogen in N-waste")
+    n_CN::N =
+        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in N-waste")   # n_CN = 0 or 1 by definition
+    n_HN::N = Param(
+        0.8,
+        units = nothing,
+        free = (0),
+        label = "chem. index of hydrogen in N-waste",
+    )
+    n_ON::N =
+        Param(0.6, units = nothing, free = (0), label = "chem. index of oxygen in N-waste")
+    n_NN::N = Param(
+        0.8,
+        units = nothing,
+        free = (0),
+        label = "chem. index of nitrogen in N-waste",
+    )
 end
 @with_kw mutable struct metaPar_struct
     model = "std"

--- a/example/pars_init_Emydura_macquarii.jl
+++ b/example/pars_init_Emydura_macquarii.jl
@@ -1,233 +1,97 @@
 Base.@kwdef struct Par{T,Z,L,K,V,PV,PS,R,EV,E,RR,S,D,DM,F,EM,N}
     # reference parameter (not to be changed) 
-    T_ref::T =
-        Param(20.0 + 273.15, units = u"K", free = (0), label = "Reference Temperature")
+    T_ref::T = Param(20.0 + 273.15, units=u"K", free=(0), label="Reference Temperature")
 
     # core primary parameters 
-    z::N = Param(13.2002, units = nothing, free = (1), label = "zoom factor")
-    F_m::L = Param(
-        6.5,
-        units = u"l/d/cm^2",
-        free = (0),
-        label = "{F_m}, max spec searching rate",
-    )
-    kap_X::K = Param(
-        0.8,
-        units = nothing,
-        free = (0),
-        label = "digestion efficiency of food to reserve",
-    )
-    kap_P::K = Param(
-        0.1,
-        units = nothing,
-        free = (0),
-        label = "faecation efficiency of food to faeces",
-    )
-    v::V = Param(0.060464, units = u"cm/d", free = (1), label = "energy conductance")
-    kap::K =
-        Param(0.7362, units = nothing, free = (1), label = "allocation fraction to soma")
-    kap_R::K = Param(0.95, units = nothing, free = (0), label = "reproduction efficiency")
-    p_M::PV = Param(
-        16.4025,
-        units = u"J/d/cm^3",
-        free = (1),
-        label = "[p_M], vol-spec somatic maint",
-    )
-    p_T::PS = Param(
-        0.0,
-        units = u"J/d/cm^2",
-        free = (0),
-        label = "{p_T}, surf-spec somatic maint",
-    )
-    k_J::R = Param(
-        0.00060219,
-        units = u"1/d",
-        free = (1),
-        label = "maturity maint rate coefficient",
-    )
-    E_G::EV = Param(
-        7857.8605,
-        units = u"J/cm^3",
-        free = (1),
-        label = "[E_G], spec cost for structure",
-    )
-    E_Hb::E = Param(1.366e+04, units = u"J", free = (1), label = "maturity at birth")
-    E_Hp::E = Param(1.168e+07, units = u"J", free = (1), label = "maturity at puberty")
-    h_a::RR =
-        Param(1.211e-09, units = u"1/d^2", free = (1), label = "Weibull aging acceleration")
-    s_G::S =
-        Param(0.0001, units = nothing, free = (0), label = "Gompertz stress coefficient")
+    z::N = Param(13.2002, units=nothing, free=(1), label="zoom factor")
+    F_m::L = Param(6.5, units=u"l/d/cm^2", free=(0), label="{F_m}, max spec searching rate")
+    kap_X::K = Param(0.8, units=nothing, free=(0), label="digestion efficiency of food to reserve")
+    kap_P::K = Param(0.1, units=nothing, free=(0), label="faecation efficiency of food to faeces")
+    v::V = Param(0.060464, units=u"cm/d", free=(1), label="energy conductance")
+    kap::K = Param(0.7362, units=nothing, free=(1), label="allocation fraction to soma")
+    kap_R::K = Param(0.95, units=nothing, free=(0), label="reproduction efficiency")
+    p_M::PV = Param(16.4025, units=u"J/d/cm^3", free=(1), label="[p_M], vol-spec somatic maint")
+    p_T::PS = Param(0.0, units=u"J/d/cm^2", free=(0), label="{p_T}, surf-spec somatic maint")
+    k_J::R = Param(0.00060219, units=u"1/d", free=(1), label="maturity maint rate coefficient")
+    E_G::EV = Param(7857.8605, units=u"J/cm^3", free=(1), label="[E_G], spec cost for structure")
+    E_Hb::E = Param(1.366e+04, units=u"J", free=(1), label="maturity at birth")
+    E_Hp::E = Param(1.168e+07, units=u"J", free=(1), label="maturity at puberty")
+    h_a::RR = Param(1.211e-09, units=u"1/d^2", free=(1), label="Weibull aging acceleration")
+    s_G::S = Param(0.0001, units=nothing, free=(0), label="Gompertz stress coefficient")
 
     # other parameters 
-    E_Hpm::E =
-        Param(4.711e+06, units = u"J", free = (1), label = "maturity at puberty for male")
-    T_A::T = Param(8000.0, units = u"K", free = (0), label = "Arrhenius temperature")
+    E_Hpm::E = Param(4.711e+06, units=u"J", free=(1), label="maturity at puberty for male")
+    T_A::T = Param(8000.0, units=u"K", free=(0), label="Arrhenius temperature")
     #T_AL::T = Param(50000.0, units=u"K", free=(0), label="low temp boundary")
     #T_AH::T = Param(50000.0, units=u"K", free=(0), label="high temp boundary")
     #T_L::T = Param(0 + 273.15, units=u"K", free=(0), label="low Arrhenius temperature")
     #T_H::T = Param(54.5 + 273.15, units=u"K", free=(0), label="high Arrhenius temperature")
-    del_M::DM = Param(0.61719, units = nothing, free = (1), label = "shape coefficient")
-    f::F = Param(
-        1.0,
-        units = nothing,
-        free = (0),
-        label = "scaled functional response for 0-var data",
-    )
-    z_m::Z = Param(13.2002, units = u"cm", free = (1), label = "zoom factor for male")
+    del_M::DM = Param(0.61719, units=nothing, free=(1), label="shape coefficient")
+    f::F = Param(1.0, units=nothing, free=(0), label="scaled functional response for 0-var data")
+    z_m::Z = Param(13.2002, units=u"cm", free=(1), label="zoom factor for male")
 
     # chemical parameters
     # specific densities; multiply free by d_V to convert to vector if necessary
-    d_X::D = Param(0.3, units = u"g/cm^3", free = (0), label = "specific density of food")
-    d_V::D =
-        Param(0.3, units = u"g/cm^3", free = (0), label = "specific density of structure")
-    d_E::D =
-        Param(0.3, units = u"g/cm^3", free = (0), label = "specific density of reserve")
-    d_P::D = Param(0.3, units = u"g/cm^3", free = (0), label = "specific density of faeces")
+    d_X::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of food")
+    d_V::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of structure")
+    d_E::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of reserve")
+    d_P::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of faeces")
 
     # chemical potentials from Kooy2010 Tab 4.2
-    mu_X::EM =
-        Param(525000.0, units = u"J/ mol", free = (0), label = "chemical potential of food")
-    mu_V::EM = Param(
-        500000.0,
-        units = u"J/ mol",
-        free = (0),
-        label = "chemical potential of structure",
-    )
-    mu_E::EM = Param(
-        550000.0,
-        units = u"J/ mol",
-        free = (0),
-        label = "chemical potential of reserve",
-    )
-    mu_P::EM = Param(
-        480000.0,
-        units = u"J/ mol",
-        free = (0),
-        label = "chemical potential of faeces",
-    )
+    mu_X::EM = Param(525000.0, units=u"J/ mol", free=(0), label="chemical potential of food")
+    mu_V::EM = Param(500000.0, units=u"J/ mol", free=(0), label="chemical potential of structure")
+    mu_E::EM = Param(550000.0, units=u"J/ mol", free=(0), label="chemical potential of reserve")
+    mu_P::EM = Param(480000.0, units=u"J/ mol", free=(0), label="chemical potential of faeces")
 
     # chemical potential of minerals
-    mu_C::EM =
-        Param(0.0, units = u"J/ mol", free = (0), label = "chemical potential of CO2")
-    mu_H::EM =
-        Param(0.0, units = u"J/ mol", free = (0), label = "chemical potential of H2O")
-    mu_O::EM = Param(0.0, units = u"J/ mol", free = (0), label = "chemical potential of O2")
-    mu_N::EM = Param(
-        4880.0,
-        units = u"J/ mol",
-        free = (0),
-        label = "chemical potential of N-waste",
-    )
+    mu_C::EM = Param(0.0, units=u"J/ mol", free=(0), label="chemical potential of CO2")
+    mu_H::EM = Param(0.0, units=u"J/ mol", free=(0), label="chemical potential of H2O")
+    mu_O::EM = Param(0.0, units=u"J/ mol", free=(0), label="chemical potential of O2")
+    mu_N::EM = Param(4880.0, units=u"J/ mol", free=(0), label="chemical potential of N-waste")
 
     # chemical indices for water-free organics from Kooy2010 Fig 4.15 (excluding contributions of H and O atoms from water)
     # food
-    n_CX::N =
-        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in food") # C/C = 1 by definition
-    n_HX::N =
-        Param(1.8, units = nothing, free = (0), label = "chem. index of hydrogen in food")
-    n_OX::N =
-        Param(0.5, units = nothing, free = (0), label = "chem. index of oxygen in food")
-    n_NX::N =
-        Param(0.15, units = nothing, free = (0), label = "chem. index of nitrogen in food")
+    n_CX::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in food") # C/C = 1 by definition
+    n_HX::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in food")
+    n_OX::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in food")
+    n_NX::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in food")
     # structure
-    n_CV::N = Param(
-        1.0,
-        units = nothing,
-        free = (0),
-        label = "chem. index of carbon in structure",
-    ) # n_CV = 1 by definition
-    n_HV::N = Param(
-        1.8,
-        units = nothing,
-        free = (0),
-        label = "chem. index of hydrogen in structure",
-    )
-    n_OV::N = Param(
-        0.5,
-        units = nothing,
-        free = (0),
-        label = "chem. index of oxygen in structure",
-    )
-    n_NV::N = Param(
-        0.15,
-        units = nothing,
-        free = (0),
-        label = "chem. index of nitrogen in structure",
-    )
+    n_CV::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in structure") # n_CV = 1 by definition
+    n_HV::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in structure")
+    n_OV::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in structure")
+    n_NV::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in structure")
     # reserve
-    n_CE::N =
-        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in reserve")   # n_CE = 1 by definition
-    n_HE::N = Param(
-        1.8,
-        units = nothing,
-        free = (0),
-        label = "chem. index of hydrogen in reserve",
-    )
-    n_OE::N =
-        Param(0.5, units = nothing, free = (0), label = "chem. index of oxygen in reserve")
-    n_NE::N = Param(
-        0.15,
-        units = nothing,
-        free = (0),
-        label = "chem. index of nitrogen in reserve",
-    )
+    n_CE::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in reserve")   # n_CE = 1 by definition
+    n_HE::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in reserve")
+    n_OE::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in reserve")
+    n_NE::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in reserve")
     # faeces
-    n_CP::N =
-        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in faeces")    # n_CP = 1 by definition
-    n_HP::N =
-        Param(1.8, units = nothing, free = (0), label = "chem. index of hydrogen in faeces")
-    n_OP::N =
-        Param(0.5, units = nothing, free = (0), label = "chem. index of oxygen in faeces")
-    n_NP::N = Param(
-        0.15,
-        units = nothing,
-        free = (0),
-        label = "chem. index of nitrogen in faeces",
-    )
+    n_CP::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in faeces")    # n_CP = 1 by definition
+    n_HP::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in faeces")
+    n_OP::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in faeces")
+    n_NP::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in faeces")
 
     # chemical indices for minerals from Kooy2010 
     # CO2 
-    n_CC::N =
-        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in CO2")
-    n_HC::N =
-        Param(0.0, units = nothing, free = (0), label = "chem. index of hydrogen in CO2")
-    n_OC::N =
-        Param(2.0, units = nothing, free = (0), label = "chem. index of oxygen in CO2")
-    n_NC::N =
-        Param(0.0, units = nothing, free = (0), label = "chem. index of nitrogen in CO2")
+    n_CC::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in CO2")
+    n_HC::N = Param(0.0, units=nothing, free=(0), label="chem. index of hydrogen in CO2")
+    n_OC::N = Param(2.0, units=nothing, free=(0), label="chem. index of oxygen in CO2")
+    n_NC::N = Param(0.0, units=nothing, free=(0), label="chem. index of nitrogen in CO2")
     # H2O
-    n_CH::N =
-        Param(0.0, units = nothing, free = (0), label = "chem. index of carbon in H2O")
-    n_HH::N =
-        Param(2.0, units = nothing, free = (0), label = "chem. index of hydrogen in H2O")
-    n_OH::N =
-        Param(1.0, units = nothing, free = (0), label = "chem. index of oxygen in H2O")
-    n_NH::N =
-        Param(0.0, units = nothing, free = (0), label = "chem. index of nitrogen in H2O")
+    n_CH::N = Param(0.0, units=nothing, free=(0), label="chem. index of carbon in H2O")
+    n_HH::N = Param(2.0, units=nothing, free=(0), label="chem. index of hydrogen in H2O")
+    n_OH::N = Param(1.0, units=nothing, free=(0), label="chem. index of oxygen in H2O")
+    n_NH::N = Param(0.0, units=nothing, free=(0), label="chem. index of nitrogen in H2O")
     # O2
-    n_CO::N = Param(0.0, units = nothing, free = (0), label = "chem. index of carbon in O2")
-    n_HO::N =
-        Param(0.0, units = nothing, free = (0), label = "chem. index of hydrogen in O2")
-    n_OO::N = Param(2.0, units = nothing, free = (0), label = "chem. index of oxygen in O2")
-    n_NO::N =
-        Param(0.0, units = nothing, free = (0), label = "chem. index of nitrogen in O2")
+    n_CO::N = Param(0.0, units=nothing, free=(0), label="chem. index of carbon in O2")
+    n_HO::N = Param(0.0, units=nothing, free=(0), label="chem. index of hydrogen in O2")
+    n_OO::N = Param(2.0, units=nothing, free=(0), label="chem. index of oxygen in O2")
+    n_NO::N = Param(0.0, units=nothing, free=(0), label="chem. index of nitrogen in O2")
     # N-waste; multiply free by par to convert to vector if necessary
-    n_CN::N =
-        Param(1.0, units = nothing, free = (0), label = "chem. index of carbon in N-waste")   # n_CN = 0 or 1 by definition
-    n_HN::N = Param(
-        0.8,
-        units = nothing,
-        free = (0),
-        label = "chem. index of hydrogen in N-waste",
-    )
-    n_ON::N =
-        Param(0.6, units = nothing, free = (0), label = "chem. index of oxygen in N-waste")
-    n_NN::N = Param(
-        0.8,
-        units = nothing,
-        free = (0),
-        label = "chem. index of nitrogen in N-waste",
-    )
+    n_CN::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in N-waste")   # n_CN = 0 or 1 by definition
+    n_HN::N = Param(0.8, units=nothing, free=(0), label="chem. index of hydrogen in N-waste")
+    n_ON::N = Param(0.6, units=nothing, free=(0), label="chem. index of oxygen in N-waste")
+    n_NN::N = Param(0.8, units=nothing, free=(0), label="chem. index of nitrogen in N-waste")
 end
 @with_kw mutable struct metaPar_struct
     model = "std"

--- a/example/predict_Emydura_macquarii.jl
+++ b/example/predict_Emydura_macquarii.jl
@@ -1,81 +1,18 @@
 function predict_Emydura_macquarii(par, data, auxData)# predict
     cPar = parscomp_st(par)
     @unpack T_ref, T_A, del_M, f, kap, kap_R, v, k_J, h_a, s_G, p_M, z_m, E_G = par
-    @unpack k, l_T, v_Hb, v_Hp, L_m, w, k_M, w, L_T, U_Hb, U_Hp, w_E, w_V, y_E_V, v_Hpm =
-        cPar
+    @unpack k, l_T, v_Hb, v_Hp, L_m, w, k_M, w, L_T, U_Hb, U_Hp, w_E, w_V, y_E_V, v_Hpm = cPar 
     @unpack temp = auxData
-    @unpack Lb,
-    Li,
-    Lim,
-    Lp,
-    Lpm,
-    Ri,
-    Wwb,
-    Wwi,
-    Wwim,
-    Wwp,
-    Wwpm,
-    ab,
-    ab30,
-    am,
-    psd,
-    tL,
-    tp,
-    tpm = data
-    @unpack E_V,
-    J_E_M,
-    M_Hb,
-    U_Hb,
-    V_Hp,
-    eta_VG,
-    j_E_J,
-    k_M,
-    m_Em,
-    ome,
-    s_H,
-    v_Hb,
-    w_E,
-    w_X,
-    y_P_E,
-    y_X_E,
-    E_m,
-    J_E_T,
-    L_T,
-    M_Hp,
-    U_Hp,
-    eta_O,
-    eta_XA,
-    j_E_M,
-    kap_G,
-    n_M,
-    p_Am,
-    u_Hb,
-    v_Hp,
-    w_P,
-    y_E_V,
-    y_P_X,
-    y_X_P,
-    J_E_Am,
-    J_X_Am,
-    L_m,
-    M_V,
-    V_Hb,
-    eta_PA,
-    k,
-    l_T,
-    n_O,
-    p_Xm,
-    u_Hp,
-    w,
-    w_V,
-    y_E_X,
-    y_V_E = cPar
+    @unpack Lb, Li, Lim, Lp, Lpm, Ri, Wwb, Wwi, Wwim, Wwp, Wwpm, ab, ab30, am, psd, tL, tp, tpm = data
+    @unpack E_V, J_E_M, M_Hb, U_Hb, V_Hp, eta_VG, j_E_J, k_M, m_Em, ome, s_H, v_Hb, w_E, w_X, y_P_E, y_X_E,
+    E_m, J_E_T, L_T, M_Hp, U_Hp, eta_O, eta_XA, j_E_M, kap_G, n_M, p_Am, u_Hb, v_Hp, w_P, y_E_V, y_P_X, y_X_P,
+    J_E_Am, J_X_Am, L_m, M_V, V_Hb, eta_PA, k, l_T, n_O, p_Xm, u_Hp, w, w_V, y_E_X, y_V_E = cPar
     g2 = cPar.g
     # compute temperature correction factors
-    TC = tempcorr(temp.am, T_ref, T_A)
-    TC_30 = tempcorr(temp.ab30, T_ref, T_A)
-    TC_Ri = tempcorr(temp.ri, T_ref, T_A)
-    TC_am = tempcorr(temp.am, T_ref, T_A)
+    TC = tempcorr(temp.am, T_ref, T_A);
+    TC_30 = tempcorr(temp.ab30, T_ref, T_A);
+    TC_Ri = tempcorr(temp.ri, T_ref, T_A);
+    TC_am = tempcorr(temp.am, T_ref, T_A);
 
     d_V = 1g / cm^3                # cm, physical length at birth at f
 

--- a/example/predict_Emydura_macquarii.jl
+++ b/example/predict_Emydura_macquarii.jl
@@ -1,94 +1,177 @@
 function predict_Emydura_macquarii(par, data, auxData)# predict
-cPar = parscomp_st(par)
-@unpack T_ref, T_A, del_M, f, kap, kap_R, v, k_J, h_a, s_G, p_M, z_m, E_G = par
-@unpack k, l_T, v_Hb, v_Hp, L_m, w, k_M, w, L_T, U_Hb, U_Hp, w_E, w_V, y_E_V, v_Hpm = cPar 
-@unpack temp = auxData
-@unpack Lb, Li, Lim, Lp, Lpm, Ri, Wwb, Wwi, Wwim, Wwp, Wwpm, ab, ab30, am, psd, tL, tp, tpm = data
-@unpack E_V, J_E_M, M_Hb, U_Hb, V_Hp, eta_VG, j_E_J, k_M, m_Em, ome, s_H, v_Hb, w_E, w_X, y_P_E, y_X_E,
-E_m, J_E_T, L_T, M_Hp, U_Hp, eta_O, eta_XA, j_E_M, kap_G, n_M, p_Am, u_Hb, v_Hp, w_P, y_E_V, y_P_X, y_X_P,
-J_E_Am, J_X_Am, L_m, M_V, V_Hb, eta_PA, k, l_T, n_O, p_Xm, u_Hp, w, w_V, y_E_X, y_V_E = cPar
-g2 = cPar.g
-# compute temperature correction factors
-TC = tempcorr(temp.am, T_ref, T_A);
-TC_30 = tempcorr(temp.ab30, T_ref, T_A);
-TC_Ri = tempcorr(temp.ri, T_ref, T_A);
-TC_am = tempcorr(temp.am, T_ref, T_A);
+    cPar = parscomp_st(par)
+    @unpack T_ref, T_A, del_M, f, kap, kap_R, v, k_J, h_a, s_G, p_M, z_m, E_G = par
+    @unpack k, l_T, v_Hb, v_Hp, L_m, w, k_M, w, L_T, U_Hb, U_Hp, w_E, w_V, y_E_V, v_Hpm =
+        cPar
+    @unpack temp = auxData
+    @unpack Lb,
+    Li,
+    Lim,
+    Lp,
+    Lpm,
+    Ri,
+    Wwb,
+    Wwi,
+    Wwim,
+    Wwp,
+    Wwpm,
+    ab,
+    ab30,
+    am,
+    psd,
+    tL,
+    tp,
+    tpm = data
+    @unpack E_V,
+    J_E_M,
+    M_Hb,
+    U_Hb,
+    V_Hp,
+    eta_VG,
+    j_E_J,
+    k_M,
+    m_Em,
+    ome,
+    s_H,
+    v_Hb,
+    w_E,
+    w_X,
+    y_P_E,
+    y_X_E,
+    E_m,
+    J_E_T,
+    L_T,
+    M_Hp,
+    U_Hp,
+    eta_O,
+    eta_XA,
+    j_E_M,
+    kap_G,
+    n_M,
+    p_Am,
+    u_Hb,
+    v_Hp,
+    w_P,
+    y_E_V,
+    y_P_X,
+    y_X_P,
+    J_E_Am,
+    J_X_Am,
+    L_m,
+    M_V,
+    V_Hb,
+    eta_PA,
+    k,
+    l_T,
+    n_O,
+    p_Xm,
+    u_Hp,
+    w,
+    w_V,
+    y_E_X,
+    y_V_E = cPar
+    g2 = cPar.g
+    # compute temperature correction factors
+    TC = tempcorr(temp.am, T_ref, T_A)
+    TC_30 = tempcorr(temp.ab30, T_ref, T_A)
+    TC_Ri = tempcorr(temp.ri, T_ref, T_A)
+    TC_am = tempcorr(temp.am, T_ref, T_A)
 
-d_V = 1g/cm^3                # cm, physical length at birth at f
+    d_V = 1g / cm^3                # cm, physical length at birth at f
 
-pars_tp = [g2 k l_T v_Hb v_Hp]
-t_p, t_b, l_p, l_b, info = get_tp(pars_tp, f)
+    pars_tp = [g2 k l_T v_Hb v_Hp]
+    t_p, t_b, l_p, l_b, info = get_tp(pars_tp, f)
 
-# birth
-L_b = L_m * l_b;                  # cm, structural length at birth at f
-Lw_b = L_b/ del_M;
-Ww_b = L_b^3 * d_V * (1 + f * w);       # g, wet weight at birth at f
-a_b = t_b/ k_M; aT_b = a_b/ TC; a30_b = a_b/ TC_30; # d, age at birth
+    # birth
+    L_b = L_m * l_b                  # cm, structural length at birth at f
+    Lw_b = L_b / del_M
+    Ww_b = L_b^3 * d_V * (1 + f * w)       # g, wet weight at birth at f
+    a_b = t_b / k_M
+    aT_b = a_b / TC
+    a30_b = a_b / TC_30 # d, age at birth
 
-# puberty 
-tT_p = (t_p - t_b)/ k_M/ TC;      # d, time since birth at puberty
-L_p = L_m * l_p;                  # cm, structural length at puberty
-Lw_p = L_p/ del_M;                # cm, plastron length at puberty
-Ww_p = L_p^3 * d_V * (1 + f * w);       # g, wet weight at puberty
+    # puberty 
+    tT_p = (t_p - t_b) / k_M / TC      # d, time since birth at puberty
+    L_p = L_m * l_p                  # cm, structural length at puberty
+    Lw_p = L_p / del_M                # cm, plastron length at puberty
+    Ww_p = L_p^3 * d_V * (1 + f * w)       # g, wet weight at puberty
 
-# ultimate
-l_i = f - l_T;                    # -, scaled ultimate length
-L_i = L_m * l_i;                  # cm, ultimate structural length at f
-Lw_i = L_i/ del_M;                # cm, ultimate plastron length
-Ww_i = L_i^3 * d_V * (1 + f * w);       # g,  ultimate wet weight
+    # ultimate
+    l_i = f - l_T                    # -, scaled ultimate length
+    L_i = L_m * l_i                  # cm, ultimate structural length at f
+    Lw_i = L_i / del_M                # cm, ultimate plastron length
+    Ww_i = L_i^3 * d_V * (1 + f * w)       # g,  ultimate wet weight
 
-# reproduction
-pars_R = [kap kap_R g2 k_J k_M L_T v U_Hb U_Hp]; # compose parameter vector at T
-RT_i = TC_Ri * reprod_rate(L_i, f, pars_R)[1];             # #/d, ultimate reproduction rate at T
+    # reproduction
+    pars_R = [kap kap_R g2 k_J k_M L_T v U_Hb U_Hp] # compose parameter vector at T
+    RT_i = TC_Ri * reprod_rate(L_i, f, pars_R)[1]             # #/d, ultimate reproduction rate at T
 
-# life span
-pars_tm = [g2 l_T h_a/ k_M^2 s_G];  # compose parameter vector at T_ref
-t_m = get_tm_s(pars_tm, f, l_b)[1];      # -, scaled mean life span at T_ref
-aT_m = t_m/ k_M/ TC_am;               # d, mean life span at T
+    # life span
+    pars_tm = [g2 l_T h_a / k_M^2 s_G]  # compose parameter vector at T_ref
+    t_m = get_tm_s(pars_tm, f, l_b)[1]      # -, scaled mean life span at T_ref
+    aT_m = t_m / k_M / TC_am               # d, mean life span at T
 
-# males
-p_Am_m = z_m * p_M/ kap;             # J/d.cm^2, {p_Am} spec assimilation flux
-E_m_m = p_Am_m/ v;                   # J/cm^3, reserve capacity [E_m]
-g_m = E_G/ (kap* E_m_m);             # -, energy investment ratio
-m_Em_m = y_E_V * E_m_m/ E_G;         # mol/mol, reserve capacity 
-w_m = m_Em_m * w_E/ w_V;             # -, contribution of reserve to weight
-L_mm = v/ k_M/ g_m;                  # cm, max struct length
-pars_tpm = [g_m k l_T v_Hb v_Hpm];
-t_pm, t_bm, l_pm, l_bm = get_tp(pars_tpm, f);
-tT_pm = (t_pm - t_bm)/ k_M/ TC;      # d, time since birth at puberty
-L_pm = L_mm * l_pm; Lw_pm = L_pm/ del_M; # cm, struc, plastron length at puberty
-Ww_pm = L_pm^3 * d_V * (1 + f * w_m); # g, wet weight at puberty 
-L_im = f * L_mm; Lw_im = L_im/ del_M; # cm, ultimate struct, plastrom length
-Ww_im = L_im^3 * d_V * (1 + f * w_m);       # g, ultimate wet weight
+    # males
+    p_Am_m = z_m * p_M / kap             # J/d.cm^2, {p_Am} spec assimilation flux
+    E_m_m = p_Am_m / v                   # J/cm^3, reserve capacity [E_m]
+    g_m = E_G / (kap * E_m_m)             # -, energy investment ratio
+    m_Em_m = y_E_V * E_m_m / E_G         # mol/mol, reserve capacity 
+    w_m = m_Em_m * w_E / w_V             # -, contribution of reserve to weight
+    L_mm = v / k_M / g_m                  # cm, max struct length
+    pars_tpm = [g_m k l_T v_Hb v_Hpm]
+    t_pm, t_bm, l_pm, l_bm = get_tp(pars_tpm, f)
+    tT_pm = (t_pm - t_bm) / k_M / TC      # d, time since birth at puberty
+    L_pm = L_mm * l_pm
+    Lw_pm = L_pm / del_M # cm, struc, plastron length at puberty
+    Ww_pm = L_pm^3 * d_V * (1 + f * w_m) # g, wet weight at puberty 
+    L_im = f * L_mm
+    Lw_im = L_im / del_M # cm, ultimate struct, plastrom length
+    Ww_im = L_im^3 * d_V * (1 + f * w_m)       # g, ultimate wet weight
 
-# pack to output
-# prdData.ab = aT_b;
-# prdData.ab30 = a30_b;
-# prdData.tp = tT_p;
-# prdData.tpm = tT_pm;
-# prdData.am = aT_m;
-# prdData.Lb = Lw_b;
-# prdData.Lp = Lw_p;
-# prdData.Lpm = Lw_pm;
-# prdData.Li = Lw_i;
-# prdData.Lim = Lw_im;
-# prdData.Wwb = Ww_b;
-# prdData.Wwp = Ww_p;
-# prdData.Wwpm = Ww_pm;
-# prdData.Wwi = Ww_i;
-# prdData.Wwim = Ww_im;
-# prdData.Ri = RT_i;
-  
-# uni-variate data
-  
-# time-length
-rT_B = TC * k_M/ 3/ (1 + f/ g2);
-ELw = Lw_i .- (Lw_i - Lw_b) * exp.(-rT_B * data.tL[1]);
+    # pack to output
+    # prdData.ab = aT_b;
+    # prdData.ab30 = a30_b;
+    # prdData.tp = tT_p;
+    # prdData.tpm = tT_pm;
+    # prdData.am = aT_m;
+    # prdData.Lb = Lw_b;
+    # prdData.Lp = Lw_p;
+    # prdData.Lpm = Lw_pm;
+    # prdData.Li = Lw_i;
+    # prdData.Lim = Lw_im;
+    # prdData.Wwb = Ww_b;
+    # prdData.Wwp = Ww_p;
+    # prdData.Wwpm = Ww_pm;
+    # prdData.Wwi = Ww_i;
+    # prdData.Wwim = Ww_im;
+    # prdData.Ri = RT_i;
 
-# pack to output
-#prdData.tL = ELw;
-prdData = (;ab = aT_b, ab30 = a30_b, tp = tT_p, tpm = tT_pm, am = aT_m, Lb = Lw_b, Lp = Lw_p, 
-Lpm = Lw_pm, Li = Lw_i, Lim = Lw_im, Wwb = Ww_b, Wwp = Ww_p, Wwpm = Ww_pm, Wwi = Ww_i, Wwim = Ww_im, Ri = RT_i,
- tL = ELw)
-return(;prdData, info)
+    # uni-variate data
+
+    # time-length
+    rT_B = TC * k_M / 3 / (1 + f / g2)
+    ELw = Lw_i .- (Lw_i - Lw_b) * exp.(-rT_B * data.tL[1])
+
+    # pack to output
+    #prdData.tL = ELw;
+    prdData = (;
+        ab = aT_b,
+        ab30 = a30_b,
+        tp = tT_p,
+        tpm = tT_pm,
+        am = aT_m,
+        Lb = Lw_b,
+        Lp = Lw_p,
+        Lpm = Lw_pm,
+        Li = Lw_i,
+        Lim = Lw_im,
+        Wwb = Ww_b,
+        Wwp = Ww_p,
+        Wwpm = Ww_pm,
+        Wwi = Ww_i,
+        Wwim = Ww_im,
+        Ri = RT_i,
+        tL = ELw,
+    )
+    return (; prdData, info)
 end

--- a/example/run_Emydura_macquarii.jl
+++ b/example/run_Emydura_macquarii.jl
@@ -9,14 +9,13 @@ include("pars_init_" * pets[1] * ".jl")
 par_model = Model(Par()) # create a 'Model' out of the Pars struct
 
 #check_my_pet(pets); 
-estim_options("default"); 
-estim_options("max_step_number", 5e2); 
-estim_options("max_fun_evals", 5e3); 
+estim_options("default");
+estim_options("max_step_number", 5e2);
+estim_options("max_fun_evals", 5e3);
 
-estim_options("pars_init_method", 2); 
-estim_options("results_output", 3); 
-estim_options("method", "nm"); 
+estim_options("pars_init_method", 2);
+estim_options("results_output", 3);
+estim_options("method", "nm");
 
 # currently takes 55 seconds to do 500 steps, matlab takes just under 40
 estim_pars(pets, par_model, metaPar)
-

--- a/example/using_pars_init_with_ModelParameters.jl
+++ b/example/using_pars_init_with_ModelParameters.jl
@@ -26,7 +26,9 @@ df = DataFrame(par)
 
 # combine values and units
 
-vals_units = NamedTuple{names}(Tuple([u === nothing ? typeof(v)(v) : v*u for (v, u) in zip(vals, units)]))
+vals_units = NamedTuple{names}(
+    Tuple([u === nothing ? typeof(v)(v) : v * u for (v, u) in zip(vals, units)]),
+)
 # explanation of line above:
 # zip(vals, units) creates an iterator that produces tuples of corresponding elements from vals and units. This iterator as two 'is' 
 # columns, one for vals and one for units and these

--- a/src/animal/dget_l_ISO.jl
+++ b/src/animal/dget_l_ISO.jl
@@ -3,9 +3,9 @@ function dget_l_ISO(vH, l, k, lT, g, f, sM)
     # l: scalar with scaled length
     # dl: scalar with d/dvH l
     # called from get_lp, get_lj, get_ls
-      
-    r = g * (f * sM - lT * sM - l)/ l/ (f + g); # specific growth rate
-    dl = l * r/ 3;                              # d/dt l
-    dvH = f * l^2 * (sM - l * r/ g) - k * vH;   # d/dt vH
-    dl = dl/ dvH;                               # dl/ dvH
-  end
+
+    r = g * (f * sM - lT * sM - l) / l / (f + g) # specific growth rate
+    dl = l * r / 3                              # d/dt l
+    dvH = f * l^2 * (sM - l * r / g) - k * vH   # d/dt vH
+    dl = dl / dvH                               # dl/ dvH
+end

--- a/src/animal/dget_l_ISO_t.jl
+++ b/src/animal/dget_l_ISO_t.jl
@@ -1,15 +1,15 @@
 function dget_l_ISO_t(vHl, p, t)
-  # vH: scalar with scaled maturity
-  # l: scalar with scaled length
-  # dl: scalar with d/dvH l
-  # called from get_lp, get_lj, get_ls
-  k, lT, g, f, sM, vHp = p 
+    # vH: scalar with scaled maturity
+    # l: scalar with scaled length
+    # dl: scalar with d/dvH l
+    # called from get_lp, get_lj, get_ls
+    k, lT, g, f, sM, vHp = p
 
-  vH = vHl[1]
-  l = vHl[2]
-  r = g * (f * sM - lT * sM - l)/ l/ (f + g) # specific growth rate
-  dl = l * r/ 3                              # d/dt l
-  dvH = f * l^2 * (sM - l * r/ g) - k * vH   # d/dt vH
-  
-  dvHl = [dvH, dl]
+    vH = vHl[1]
+    l = vHl[2]
+    r = g * (f * sM - lT * sM - l) / l / (f + g) # specific growth rate
+    dl = l * r / 3                              # d/dt l
+    dvH = f * l^2 * (sM - l * r / g) - k * vH   # d/dt vH
+
+    dvHl = [dvH, dl]
 end

--- a/src/animal/get_lb.jl
+++ b/src/animal/get_lb.jl
@@ -3,317 +3,356 @@
 
 ##
 function get_lb(p, eb, lb0)
-  # created 2007/08/15 by Bas Kooijman; modified 2013/08/19, 2015/01/20
-  
-  ## Syntax
-  # [lb, info] = <../get_lb.m *get_lb*>(p, eb, lb0)
-  
-  ## Description
-  # Obtains scaled length at birth, given the scaled reserve density at birth. 
-  #
-  # Input
-  #
-  # * p: 3-vector with parameters: g, k, v_H^b (see below)
-  # * eb: optional scalar with scaled reserve density at birth (default eb = 1)
-  # * lb0: optional scalar with initial estimate for scaled length at birth (default lb0: lb for k = 1)
-  #  
-  # Output
-  #
-  # * lb: scalar with scaled length at birth 
-  # * info: indicator equals 1 if successful, 0 otherwise
-  
-  ## Remarks
-  # The theory behind get_lb, get_tb and get_ue0 is discussed in 
-  #    <http://www.bio.vu.nl/thb/research/bib/Kooy2009b.html Kooy2009b>.
-  # Solves y(x_b) = y_b  for lb with explicit solution for y(x)
-  #   y(x) = x e_H/(1-kap) = x g u_H/ l^3
-  #   and y_b = x_b g u_H^b/ ((1-kap)l_b^3)
-  #   d/dx y = r(x) - y s(x);
-  #   with solution y(x) = v(x) \int r(x)/ v(x) dx
-  #   and v(x) = exp(- \int s(x) dx).
-  # A Newton Raphson scheme is used with Euler integration, starting from an optional initial value. 
-  # Replacement of Euler integration by ode23: <get_lb1.html *get_lb1*>,
-  #  but that function is much lower.
-  # Shooting method: <get_lb2.html *get_lb2*>.
-  # Bisection method (via fzero): <get_lb3.html *get_lb3*>.
-  # In case of no convergence, <get_lb2.html *get_lb2*> is run automatically as backup.
-  # Consider the application of <get_lb_foetus.html *get_lb_foetus*> for an alternative initial value.
+    # created 2007/08/15 by Bas Kooijman; modified 2013/08/19, 2015/01/20
 
-  ## Example of use
-  # See <../mydata_ue0.m *mydata_ue0*>
-  
-  #  unpack p
-  g, k, vHb = p   # g = [E_G] * v/ kap * {p_Am}, energy investment ratio
-                # k = k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
-                # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm}
+    ## Syntax
+    # [lb, info] = <../get_lb.m *get_lb*>(p, eb, lb0)
 
-  info = true;
-  if !@isdefined(lb0)
-    lb0 = [;];
-  end
-   
-  if k == 1
-    lb = vHb^(1/ 3); # exact solution for k = 1
-    info = true;
-    return;
-  end
-  if isempty(lb0)
-    lb = vHb^(1/ 3); # exact solution for k = 1     
-  else
-    lb = lb0;
-  end
-  if !@isdefined(eb)
-    eb = 1;
-  elseif isempty(eb)
-    eb = 1;
-  end
-       
-  n = 1000 + round(1000 * max(0, k - 1)); xb = g/ (g + eb); xb3 = xb ^ (1/3);
-  x = LinRange(1e-6, xb, trunc(Int, n)); dx = xb/ n;  x3 = x .^ (1/3);
-  
-  b = real(beta0(x, xb))/ (3 * g); t0 = xb * g * vHb;
-  i = 0; norm = 1; # make sure that we start Newton Raphson procedure
-  ni = 100; # max number of iterations
-  
-  while i < ni  && norm > 1e-8
-    l = x3 ./ (xb3/ lb .- b);
-    s = (k .- x) ./ (1 .- x) .* l/ g ./ x;
-    v = exp.( - dx * cumsum(s)); vb = v[trunc(Int, n)];
-    r = (g .+ l); rv = r ./ v;
-    t = t0/ lb^3/ vb - dx * sum(rv);
-    dl = xb3/ lb^2 * l .^ 2 ./ x3; dlnl = dl ./ l;
-    dv = v .* exp.( - dx * cumsum(s .* dlnl));
-    dvb = dv[trunc(Int, n)]; dlnv = dv ./ v; dlnvb = dlnv[trunc(Int, n)];
-    dr = dl; dlnr = dr ./ r;
-    dt = - t0/ lb^3/ vb * (3/ lb + dlnvb) - dx * sum((dlnr - dlnv) .* rv);
-    # [i lb t dt] # print progress
-    lb = lb - t/ dt; # Newton Raphson step
-    norm = t^2; i = i + 1;
-  end
-  (lb)  
-  if i == ni || lb < 0 || lb > 1 || isnan(norm) || isnan(lb) # no convergence
-    # try to recover with a shooting method
-    if isempty(lb0)
-      lb, info = get_lb2(p, eb);
-    elseif lb0 < 1 && lb0 > 0
-      lb, info = get_lb2(p, eb, lb0);
-    else
-      lb, info = get_lb2(p, eb);
+    ## Description
+    # Obtains scaled length at birth, given the scaled reserve density at birth. 
+    #
+    # Input
+    #
+    # * p: 3-vector with parameters: g, k, v_H^b (see below)
+    # * eb: optional scalar with scaled reserve density at birth (default eb = 1)
+    # * lb0: optional scalar with initial estimate for scaled length at birth (default lb0: lb for k = 1)
+    #  
+    # Output
+    #
+    # * lb: scalar with scaled length at birth 
+    # * info: indicator equals 1 if successful, 0 otherwise
+
+    ## Remarks
+    # The theory behind get_lb, get_tb and get_ue0 is discussed in 
+    #    <http://www.bio.vu.nl/thb/research/bib/Kooy2009b.html Kooy2009b>.
+    # Solves y(x_b) = y_b  for lb with explicit solution for y(x)
+    #   y(x) = x e_H/(1-kap) = x g u_H/ l^3
+    #   and y_b = x_b g u_H^b/ ((1-kap)l_b^3)
+    #   d/dx y = r(x) - y s(x);
+    #   with solution y(x) = v(x) \int r(x)/ v(x) dx
+    #   and v(x) = exp(- \int s(x) dx).
+    # A Newton Raphson scheme is used with Euler integration, starting from an optional initial value. 
+    # Replacement of Euler integration by ode23: <get_lb1.html *get_lb1*>,
+    #  but that function is much lower.
+    # Shooting method: <get_lb2.html *get_lb2*>.
+    # Bisection method (via fzero): <get_lb3.html *get_lb3*>.
+    # In case of no convergence, <get_lb2.html *get_lb2*> is run automatically as backup.
+    # Consider the application of <get_lb_foetus.html *get_lb_foetus*> for an alternative initial value.
+
+    ## Example of use
+    # See <../mydata_ue0.m *mydata_ue0*>
+
+    #  unpack p
+    g, k, vHb = p   # g = [E_G] * v/ kap * {p_Am}, energy investment ratio
+    # k = k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
+    # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm}
+
+    info = true
+    if !@isdefined(lb0)
+        lb0 = [;]
     end
-  end
-  
-  if info == false
-    println("warning get_lb: no convergence of l_b \n");
-  end
+
+    if k == 1
+        lb = vHb^(1 / 3) # exact solution for k = 1
+        info = true
+        return
+    end
+    if isempty(lb0)
+        lb = vHb^(1 / 3) # exact solution for k = 1     
+    else
+        lb = lb0
+    end
+    if !@isdefined(eb)
+        eb = 1
+    elseif isempty(eb)
+        eb = 1
+    end
+
+    n = 1000 + round(1000 * max(0, k - 1))
+    xb = g / (g + eb)
+    xb3 = xb^(1 / 3)
+    x = LinRange(1e-6, xb, trunc(Int, n))
+    dx = xb / n
+    x3 = x .^ (1 / 3)
+
+    b = real(beta0(x, xb)) / (3 * g)
+    t0 = xb * g * vHb
+    i = 0
+    norm = 1 # make sure that we start Newton Raphson procedure
+    ni = 100 # max number of iterations
+
+    while i < ni && norm > 1e-8
+        l = x3 ./ (xb3 / lb .- b)
+        s = (k .- x) ./ (1 .- x) .* l / g ./ x
+        v = exp.(-dx * cumsum(s))
+        vb = v[trunc(Int, n)]
+        r = (g .+ l)
+        rv = r ./ v
+        t = t0 / lb^3 / vb - dx * sum(rv)
+        dl = xb3 / lb^2 * l .^ 2 ./ x3
+        dlnl = dl ./ l
+        dv = v .* exp.(-dx * cumsum(s .* dlnl))
+        dvb = dv[trunc(Int, n)]
+        dlnv = dv ./ v
+        dlnvb = dlnv[trunc(Int, n)]
+        dr = dl
+        dlnr = dr ./ r
+        dt = -t0 / lb^3 / vb * (3 / lb + dlnvb) - dx * sum((dlnr - dlnv) .* rv)
+        # [i lb t dt] # print progress
+        lb = lb - t / dt # Newton Raphson step
+        norm = t^2
+        i = i + 1
+    end
+    (lb)
+    if i == ni || lb < 0 || lb > 1 || isnan(norm) || isnan(lb) # no convergence
+        # try to recover with a shooting method
+        if isempty(lb0)
+            lb, info = get_lb2(p, eb)
+        elseif lb0 < 1 && lb0 > 0
+            lb, info = get_lb2(p, eb, lb0)
+        else
+            lb, info = get_lb2(p, eb)
+        end
+    end
+
+    if info == false
+        println("warning get_lb: no convergence of l_b \n")
+    end
     (lb, info)
 end
 
 function get_lb(p, eb)
-  # created 2007/08/15 by Bas Kooijman; modified 2013/08/19, 2015/01/20
-  
-  ## Syntax
-  # [lb, info] = <../get_lb.m *get_lb*>(p, eb)
-  
-  ## Description
-  # Obtains scaled length at birth, given the scaled reserve density at birth. 
-  #
-  # Input
-  #
-  # * p: 3-vector with parameters: g, k, v_H^b (see below)
-  # * eb: optional scalar with scaled reserve density at birth (default eb = 1)
-  #  
-  # Output
-  #
-  # * lb: scalar with scaled length at birth 
-  # * info: indicator equals 1 if successful, 0 otherwise
-  
-  ## Remarks
-  # The theory behind get_lb, get_tb and get_ue0 is discussed in 
-  #    <http://www.bio.vu.nl/thb/research/bib/Kooy2009b.html Kooy2009b>.
-  # Solves y(x_b) = y_b  for lb with explicit solution for y(x)
-  #   y(x) = x e_H/(1-kap) = x g u_H/ l^3
-  #   and y_b = x_b g u_H^b/ ((1-kap)l_b^3)
-  #   d/dx y = r(x) - y s(x);
-  #   with solution y(x) = v(x) \int r(x)/ v(x) dx
-  #   and v(x) = exp(- \int s(x) dx).
-  # A Newton Raphson scheme is used with Euler integration, starting from an optional initial value. 
-  # Replacement of Euler integration by ode23: <get_lb1.html *get_lb1*>,
-  #  but that function is much lower.
-  # Shooting method: <get_lb2.html *get_lb2*>.
-  # Bisection method (via fzero): <get_lb3.html *get_lb3*>.
-  # In case of no convergence, <get_lb2.html *get_lb2*> is run automatically as backup.
-  # Consider the application of <get_lb_foetus.html *get_lb_foetus*> for an alternative initial value.
+    # created 2007/08/15 by Bas Kooijman; modified 2013/08/19, 2015/01/20
 
-  ## Example of use
-  # See <../mydata_ue0.m *mydata_ue0*>
-  
-  #  unpack p
-  g, k, vHb = p   # g = [E_G] * v/ kap * {p_Am}, energy investment ratio
-                # k = k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
-                # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm}
+    ## Syntax
+    # [lb, info] = <../get_lb.m *get_lb*>(p, eb)
 
-  info = true;
-  # if !@isdefined(lb0)
-  #   lb0 = [;];
-  # end
-   
-  if k == 1
-    lb = vHb^(1/ 3); # exact solution for k = 1
-    info = true;
-    return;
-  end
-  # if isempty(lb0)
-    lb = vHb^(1/ 3); # exact solution for k = 1     
-  # else
-  #   lb = lb0;
-  # end
-  if !@isdefined(eb)
-    eb = 1.0;
-  elseif isempty(eb)
-    eb = 1.0;
-  end
-       
-  n = 1000 + round(1000 * max(0, k - 1)); xb = g/ (g + eb); xb3 = xb ^ (1/3);
-  x = LinRange(1e-6, xb, trunc(Int, n)); dx = xb/ n;  x3 = x .^ (1/3);
-  
-  b = real(beta0(x, xb))/ (3 * g); t0 = xb * g * vHb;
-  i = 0; norm = 1; # make sure that we start Newton Raphson procedure
-  ni = 100; # max number of iterations
-  
-  while i < ni  && norm > 1e-8
-    l = x3 ./ (xb3/ lb .- b);
-    s = (k .- x) ./ (1 .- x) .* l/ g ./ x;
-    v = exp.( - dx * cumsum(s)); vb = v[trunc(Int, n)];
-    r = (g .+ l); rv = r ./ v;
-    t = t0/ lb^3/ vb - dx * sum(rv);
-    dl = xb3/ lb^2 * l .^ 2 ./ x3; dlnl = dl ./ l;
-    dv = v .* exp.( - dx * cumsum(s .* dlnl));
-    dvb = dv[trunc(Int, n)]; dlnv = dv ./ v; dlnvb = dlnv[trunc(Int, n)];
-    dr = dl; dlnr = dr ./ r;
-    dt = - t0/ lb^3/ vb * (3/ lb + dlnvb) - dx * sum((dlnr - dlnv) .* rv);
-    # [i lb t dt] # print progress
-    lb = lb - t/ dt; # Newton Raphson step
-    norm = t^2; i = i + 1;
-  end
+    ## Description
+    # Obtains scaled length at birth, given the scaled reserve density at birth. 
+    #
+    # Input
+    #
+    # * p: 3-vector with parameters: g, k, v_H^b (see below)
+    # * eb: optional scalar with scaled reserve density at birth (default eb = 1)
+    #  
+    # Output
+    #
+    # * lb: scalar with scaled length at birth 
+    # * info: indicator equals 1 if successful, 0 otherwise
 
-  if i == ni || lb < 0 || lb > 1 || isnan(norm) || isnan(lb) # no convergence
-    # try to recover with a shooting method
-    # if isempty(lb0)
-      lb, info = get_lb2(p, eb);
-    # elseif lb0 < 1 && lb0 > 0
-    #   lb, info = get_lb2(p, eb, lb0);
-    # else
-    #   lb, info = get_lb2(p, eb);
+    ## Remarks
+    # The theory behind get_lb, get_tb and get_ue0 is discussed in 
+    #    <http://www.bio.vu.nl/thb/research/bib/Kooy2009b.html Kooy2009b>.
+    # Solves y(x_b) = y_b  for lb with explicit solution for y(x)
+    #   y(x) = x e_H/(1-kap) = x g u_H/ l^3
+    #   and y_b = x_b g u_H^b/ ((1-kap)l_b^3)
+    #   d/dx y = r(x) - y s(x);
+    #   with solution y(x) = v(x) \int r(x)/ v(x) dx
+    #   and v(x) = exp(- \int s(x) dx).
+    # A Newton Raphson scheme is used with Euler integration, starting from an optional initial value. 
+    # Replacement of Euler integration by ode23: <get_lb1.html *get_lb1*>,
+    #  but that function is much lower.
+    # Shooting method: <get_lb2.html *get_lb2*>.
+    # Bisection method (via fzero): <get_lb3.html *get_lb3*>.
+    # In case of no convergence, <get_lb2.html *get_lb2*> is run automatically as backup.
+    # Consider the application of <get_lb_foetus.html *get_lb_foetus*> for an alternative initial value.
+
+    ## Example of use
+    # See <../mydata_ue0.m *mydata_ue0*>
+
+    #  unpack p
+    g, k, vHb = p   # g = [E_G] * v/ kap * {p_Am}, energy investment ratio
+    # k = k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
+    # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm}
+
+    info = true
+    # if !@isdefined(lb0)
+    #   lb0 = [;];
     # end
-  end
-  
-  if info == false
-    println("warning get_lb: no convergence of l_b \n");
-  end
-  (lb, info)
+
+    if k == 1
+        lb = vHb^(1 / 3) # exact solution for k = 1
+        info = true
+        return
+    end
+    # if isempty(lb0)
+    lb = vHb^(1 / 3) # exact solution for k = 1     
+    # else
+    #   lb = lb0;
+    # end
+    if !@isdefined(eb)
+        eb = 1.0
+    elseif isempty(eb)
+        eb = 1.0
+    end
+
+    n = 1000 + round(1000 * max(0, k - 1))
+    xb = g / (g + eb)
+    xb3 = xb^(1 / 3)
+    x = LinRange(1e-6, xb, trunc(Int, n))
+    dx = xb / n
+    x3 = x .^ (1 / 3)
+
+    b = real(beta0(x, xb)) / (3 * g)
+    t0 = xb * g * vHb
+    i = 0
+    norm = 1 # make sure that we start Newton Raphson procedure
+    ni = 100 # max number of iterations
+
+    while i < ni && norm > 1e-8
+        l = x3 ./ (xb3 / lb .- b)
+        s = (k .- x) ./ (1 .- x) .* l / g ./ x
+        v = exp.(-dx * cumsum(s))
+        vb = v[trunc(Int, n)]
+        r = (g .+ l)
+        rv = r ./ v
+        t = t0 / lb^3 / vb - dx * sum(rv)
+        dl = xb3 / lb^2 * l .^ 2 ./ x3
+        dlnl = dl ./ l
+        dv = v .* exp.(-dx * cumsum(s .* dlnl))
+        dvb = dv[trunc(Int, n)]
+        dlnv = dv ./ v
+        dlnvb = dlnv[trunc(Int, n)]
+        dr = dl
+        dlnr = dr ./ r
+        dt = -t0 / lb^3 / vb * (3 / lb + dlnvb) - dx * sum((dlnr - dlnv) .* rv)
+        # [i lb t dt] # print progress
+        lb = lb - t / dt # Newton Raphson step
+        norm = t^2
+        i = i + 1
+    end
+
+    if i == ni || lb < 0 || lb > 1 || isnan(norm) || isnan(lb) # no convergence
+        # try to recover with a shooting method
+        # if isempty(lb0)
+        lb, info = get_lb2(p, eb)
+        # elseif lb0 < 1 && lb0 > 0
+        #   lb, info = get_lb2(p, eb, lb0);
+        # else
+        #   lb, info = get_lb2(p, eb);
+        # end
+    end
+
+    if info == false
+        println("warning get_lb: no convergence of l_b \n")
+    end
+    (lb, info)
 end
 
 function get_lb(p)
-  # created 2007/08/15 by Bas Kooijman; modified 2013/08/19, 2015/01/20
-  
-  ## Syntax
-  # [lb, info] = <../get_lb.m *get_lb*>(p, eb)
-  
-  ## Description
-  # Obtains scaled length at birth, given the scaled reserve density at birth. 
-  #
-  # Input
-  #
-  # * p: 3-vector with parameters: g, k, v_H^b (see below)
-  # * eb: optional scalar with scaled reserve density at birth (default eb = 1)
-  #  
-  # Output
-  #
-  # * lb: scalar with scaled length at birth 
-  # * info: indicator equals 1 if successful, 0 otherwise
-  
-  ## Remarks
-  # The theory behind get_lb, get_tb and get_ue0 is discussed in 
-  #    <http://www.bio.vu.nl/thb/research/bib/Kooy2009b.html Kooy2009b>.
-  # Solves y(x_b) = y_b  for lb with explicit solution for y(x)
-  #   y(x) = x e_H/(1-kap) = x g u_H/ l^3
-  #   and y_b = x_b g u_H^b/ ((1-kap)l_b^3)
-  #   d/dx y = r(x) - y s(x);
-  #   with solution y(x) = v(x) \int r(x)/ v(x) dx
-  #   and v(x) = exp(- \int s(x) dx).
-  # A Newton Raphson scheme is used with Euler integration, starting from an optional initial value. 
-  # Replacement of Euler integration by ode23: <get_lb1.html *get_lb1*>,
-  #  but that function is much lower.
-  # Shooting method: <get_lb2.html *get_lb2*>.
-  # Bisection method (via fzero): <get_lb3.html *get_lb3*>.
-  # In case of no convergence, <get_lb2.html *get_lb2*> is run automatically as backup.
-  # Consider the application of <get_lb_foetus.html *get_lb_foetus*> for an alternative initial value.
+    # created 2007/08/15 by Bas Kooijman; modified 2013/08/19, 2015/01/20
 
-  ## Example of use
-  # See <../mydata_ue0.m *mydata_ue0*>
-  
-  #  unpack p
-  g, k, vHb = p   # g = [E_G] * v/ kap * {p_Am}, energy investment ratio
-                # k = k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
-                # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm}
+    ## Syntax
+    # [lb, info] = <../get_lb.m *get_lb*>(p, eb)
 
-  info = true;
-  # if !@isdefined(lb0)
-  #   lb0 = [;];
-  # end
-   
-  if k == 1
-    lb = vHb^(1/ 3); # exact solution for k = 1
-    info = true;
-    return;
-  end
-  # if isempty(lb0)
-    lb = vHb^(1/ 3); # exact solution for k = 1     
-  # else
-  #   lb = lb0;
-  # end
-  #if !@isdefined(eb)
-    eb = 1;
-  #elseif isempty(eb)
-  #  eb = 1;
-  #end
-       
-  n = 1000 + round(1000 * max(0, k - 1)); xb = g/ (g + eb); xb3 = xb ^ (1/3);
-  x = LinRange(1e-6, xb, trunc(Int, n)); dx = xb/ n;  x3 = x .^ (1/3);
-  
-  b = real(beta0(x, xb))/ (3 * g); t0 = xb * g * vHb;
-  i = 0; norm = 1; # make sure that we start Newton Raphson procedure
-  ni = 100; # max number of iterations
-  
-  while i < ni  && norm > 1e-8
-    l = x3 ./ (xb3/ lb .- b);
-    s = (k .- x) ./ (1 .- x) .* l/ g ./ x;
-    v = exp.( - dx * cumsum(s)); vb = v[trunc(Int, n)];
-    r = (g .+ l); rv = r ./ v;
-    t = t0/ lb^3/ vb - dx * sum(rv);
-    dl = xb3/ lb^2 * l .^ 2 ./ x3; dlnl = dl ./ l;
-    dv = v .* exp.( - dx * cumsum(s .* dlnl));
-    dvb = dv[trunc(Int, n)]; dlnv = dv ./ v; dlnvb = dlnv[trunc(Int, n)];
-    dr = dl; dlnr = dr ./ r;
-    dt = - t0/ lb^3/ vb * (3/ lb + dlnvb) - dx * sum((dlnr - dlnv) .* rv);
-    # [i lb t dt] # print progress
-    lb = lb - t/ dt; # Newton Raphson step
-    norm = t^2; i = i + 1;
-  end
-  (lb)  
-  if i == ni || lb < 0 || lb > 1 || isnan(norm) || isnan(lb) # no convergence
-    # try to recover with a shooting method
-    # if isempty(lb0)
-      lb, info = get_lb2(p);
-    # elseif lb0 < 1 && lb0 > 0
-    #   lb, info = get_lb2(p, eb, lb0);
-    # else
-    #   lb, info = get_lb2(p, eb);
+    ## Description
+    # Obtains scaled length at birth, given the scaled reserve density at birth. 
+    #
+    # Input
+    #
+    # * p: 3-vector with parameters: g, k, v_H^b (see below)
+    # * eb: optional scalar with scaled reserve density at birth (default eb = 1)
+    #  
+    # Output
+    #
+    # * lb: scalar with scaled length at birth 
+    # * info: indicator equals 1 if successful, 0 otherwise
+
+    ## Remarks
+    # The theory behind get_lb, get_tb and get_ue0 is discussed in 
+    #    <http://www.bio.vu.nl/thb/research/bib/Kooy2009b.html Kooy2009b>.
+    # Solves y(x_b) = y_b  for lb with explicit solution for y(x)
+    #   y(x) = x e_H/(1-kap) = x g u_H/ l^3
+    #   and y_b = x_b g u_H^b/ ((1-kap)l_b^3)
+    #   d/dx y = r(x) - y s(x);
+    #   with solution y(x) = v(x) \int r(x)/ v(x) dx
+    #   and v(x) = exp(- \int s(x) dx).
+    # A Newton Raphson scheme is used with Euler integration, starting from an optional initial value. 
+    # Replacement of Euler integration by ode23: <get_lb1.html *get_lb1*>,
+    #  but that function is much lower.
+    # Shooting method: <get_lb2.html *get_lb2*>.
+    # Bisection method (via fzero): <get_lb3.html *get_lb3*>.
+    # In case of no convergence, <get_lb2.html *get_lb2*> is run automatically as backup.
+    # Consider the application of <get_lb_foetus.html *get_lb_foetus*> for an alternative initial value.
+
+    ## Example of use
+    # See <../mydata_ue0.m *mydata_ue0*>
+
+    #  unpack p
+    g, k, vHb = p   # g = [E_G] * v/ kap * {p_Am}, energy investment ratio
+    # k = k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
+    # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm}
+
+    info = true
+    # if !@isdefined(lb0)
+    #   lb0 = [;];
     # end
-  end
-  
-  if info == false
-    println("warning get_lb: no convergence of l_b \n");
-  end
-  (lb, info)
+
+    if k == 1
+        lb = vHb^(1 / 3) # exact solution for k = 1
+        info = true
+        return
+    end
+    # if isempty(lb0)
+    lb = vHb^(1 / 3) # exact solution for k = 1     
+    # else
+    #   lb = lb0;
+    # end
+    #if !@isdefined(eb)
+    eb = 1
+    #elseif isempty(eb)
+    #  eb = 1;
+    #end
+
+    n = 1000 + round(1000 * max(0, k - 1))
+    xb = g / (g + eb)
+    xb3 = xb^(1 / 3)
+    x = LinRange(1e-6, xb, trunc(Int, n))
+    dx = xb / n
+    x3 = x .^ (1 / 3)
+
+    b = real(beta0(x, xb)) / (3 * g)
+    t0 = xb * g * vHb
+    i = 0
+    norm = 1 # make sure that we start Newton Raphson procedure
+    ni = 100 # max number of iterations
+
+    while i < ni && norm > 1e-8
+        l = x3 ./ (xb3 / lb .- b)
+        s = (k .- x) ./ (1 .- x) .* l / g ./ x
+        v = exp.(-dx * cumsum(s))
+        vb = v[trunc(Int, n)]
+        r = (g .+ l)
+        rv = r ./ v
+        t = t0 / lb^3 / vb - dx * sum(rv)
+        dl = xb3 / lb^2 * l .^ 2 ./ x3
+        dlnl = dl ./ l
+        dv = v .* exp.(-dx * cumsum(s .* dlnl))
+        dvb = dv[trunc(Int, n)]
+        dlnv = dv ./ v
+        dlnvb = dlnv[trunc(Int, n)]
+        dr = dl
+        dlnr = dr ./ r
+        dt = -t0 / lb^3 / vb * (3 / lb + dlnvb) - dx * sum((dlnr - dlnv) .* rv)
+        # [i lb t dt] # print progress
+        lb = lb - t / dt # Newton Raphson step
+        norm = t^2
+        i = i + 1
+    end
+    (lb)
+    if i == ni || lb < 0 || lb > 1 || isnan(norm) || isnan(lb) # no convergence
+        # try to recover with a shooting method
+        # if isempty(lb0)
+        lb, info = get_lb2(p)
+        # elseif lb0 < 1 && lb0 > 0
+        #   lb, info = get_lb2(p, eb, lb0);
+        # else
+        #   lb, info = get_lb2(p, eb);
+        # end
+    end
+
+    if info == false
+        println("warning get_lb: no convergence of l_b \n")
+    end
+    (lb, info)
 end

--- a/src/animal/get_lb2.jl
+++ b/src/animal/get_lb2.jl
@@ -3,212 +3,212 @@
 
 ##
 function get_lb2(p, eb, lb0)
-  # created 2007/07/26 by Bas Kooijman; modified 2013/08/19, 2015/01/18
-  
-  ## Syntax
-  # [lb info] = <../get_lb2.m *get_lb2*> (p, eb, lb0)
-  
-  ## Description
-  # Obtains scaled length at birth, given the scaled reserve density at birth. 
-  # Like get_lb, but using the shooting method, rather than Newton Raphson
-  #
-  # Input
-  #
-  # * p: 3-vector with parameters: g, k, v_H^b (see below)
-  # * eb: optional scalar with scaled reserve density at birth (default eb = 1)
-  # * lb0: optional scalar with initial estimate for scaled length at birth (default lb0: lb for k = 1)
-  #  
-  # Output
-  #
-  # * lb: scalar with scaled length at birth 
-  # * info: indicator equals 1 if successful, 0 otherwise
+    # created 2007/07/26 by Bas Kooijman; modified 2013/08/19, 2015/01/18
 
-  ## Remarks
-  # Like <get_lb.html *get_lb*>, but uses a shooting method in 1 variable
+    ## Syntax
+    # [lb info] = <../get_lb2.m *get_lb2*> (p, eb, lb0)
 
-  #  unpack p
-  g = p[1];   # g = [E_G] * v/ kap * {p_Am}, energy investment ratio
-  k = p[2];   # k = k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
-  vHb = p[3]; # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm}
+    ## Description
+    # Obtains scaled length at birth, given the scaled reserve density at birth. 
+    # Like get_lb, but using the shooting method, rather than Newton Raphson
+    #
+    # Input
+    #
+    # * p: 3-vector with parameters: g, k, v_H^b (see below)
+    # * eb: optional scalar with scaled reserve density at birth (default eb = 1)
+    # * lb0: optional scalar with initial estimate for scaled length at birth (default lb0: lb for k = 1)
+    #  
+    # Output
+    #
+    # * lb: scalar with scaled length at birth 
+    # * info: indicator equals 1 if successful, 0 otherwise
 
-  info = true;
+    ## Remarks
+    # Like <get_lb.html *get_lb*>, but uses a shooting method in 1 variable
 
-  if !@isdefined(lb0) || k == 1
-    lb = vHb ^ (1/3); # exact solution for k = 1
-    if k == 1
-      return;
+    #  unpack p
+    g = p[1]   # g = [E_G] * v/ kap * {p_Am}, energy investment ratio
+    k = p[2]   # k = k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
+    vHb = p[3] # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm}
+
+    info = true
+
+    if !@isdefined(lb0) || k == 1
+        lb = vHb^(1 / 3) # exact solution for k = 1
+        if k == 1
+            return
+        end
+    elseif isempty(lb0)
+        lb = vHb^(1 / 3) # exact solution for k = 1     
+    else
+        lb = lb0
     end
-  elseif isempty(lb0)
-    lb = vHb^(1/ 3); # exact solution for k = 1     
-  else
-    lb = lb0;
-  end
-  if !@isdefined(eb)
-    eb = 1;
-  elseif isempty(eb)
-    eb = 1;
-  end
-
-  xb = g/ (eb + g); 
-  xb3 = xb^(1/3); 
-  
-  if isnan(fnget_lb2(lb, xb, xb3, g, vHb, k))
-    info = false;
-  else
-    lb = find_zero(fnget_lb2, lb, [xb, xb3, g, vHb, k]);
-
-    #lb, flag, info = fzero(@fnget_lb2, lb, [], xb, xb3, g, vHb, k);
-    if lb < 0 || lb > 1 || isnan(lb)
-      info = false;
+    if !@isdefined(eb)
+        eb = 1
+    elseif isempty(eb)
+        eb = 1
     end
-  end
-  (lb, info) 
+
+    xb = g / (eb + g)
+    xb3 = xb^(1 / 3)
+
+    if isnan(fnget_lb2(lb, xb, xb3, g, vHb, k))
+        info = false
+    else
+        lb = find_zero(fnget_lb2, lb, [xb, xb3, g, vHb, k])
+
+        #lb, flag, info = fzero(@fnget_lb2, lb, [], xb, xb3, g, vHb, k);
+        if lb < 0 || lb > 1 || isnan(lb)
+            info = false
+        end
+    end
+    (lb, info)
 end
 
 function get_lb2(p, eb)
-  # created 2007/07/26 by Bas Kooijman; modified 2013/08/19, 2015/01/18
-  
-  ## Syntax
-  # [lb info] = <../get_lb2.m *get_lb2*> (p, eb, lb0)
-  
-  ## Description
-  # Obtains scaled length at birth, given the scaled reserve density at birth. 
-  # Like get_lb, but using the shooting method, rather than Newton Raphson
-  #
-  # Input
-  #
-  # * p: 3-vector with parameters: g, k, v_H^b (see below)
-  # * eb: optional scalar with scaled reserve density at birth (default eb = 1)
-  #  
-  # Output
-  #
-  # * lb: scalar with scaled length at birth 
-  # * info: indicator equals 1 if successful, 0 otherwise
+    # created 2007/07/26 by Bas Kooijman; modified 2013/08/19, 2015/01/18
 
-  ## Remarks
-  # Like <get_lb.html *get_lb*>, but uses a shooting method in 1 variable
+    ## Syntax
+    # [lb info] = <../get_lb2.m *get_lb2*> (p, eb, lb0)
 
-  #  unpack p
-  g = p[1];   # g = [E_G] * v/ kap * {p_Am}, energy investment ratio
-  k = p[2];   # k = k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
-  vHb = p[3]; # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm}
+    ## Description
+    # Obtains scaled length at birth, given the scaled reserve density at birth. 
+    # Like get_lb, but using the shooting method, rather than Newton Raphson
+    #
+    # Input
+    #
+    # * p: 3-vector with parameters: g, k, v_H^b (see below)
+    # * eb: optional scalar with scaled reserve density at birth (default eb = 1)
+    #  
+    # Output
+    #
+    # * lb: scalar with scaled length at birth 
+    # * info: indicator equals 1 if successful, 0 otherwise
 
-  info = true;
+    ## Remarks
+    # Like <get_lb.html *get_lb*>, but uses a shooting method in 1 variable
 
-  #if !@isdefined(lb0) || k == 1
-    lb = vHb ^ (1/3); # exact solution for k = 1
+    #  unpack p
+    g = p[1]   # g = [E_G] * v/ kap * {p_Am}, energy investment ratio
+    k = p[2]   # k = k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
+    vHb = p[3] # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm}
+
+    info = true
+
+    #if !@isdefined(lb0) || k == 1
+    lb = vHb^(1 / 3) # exact solution for k = 1
     if k == 1
-      return;
+        return
     end
-  # elseif isempty(lb0)
-  #   lb = vHb^(1/ 3); # exact solution for k = 1     
-  # else
-  #   lb = lb0;
-  # end
-  # if !@isdefined(eb)
-  #   eb = 1;
-  # elseif isempty(eb)
-  #   eb = 1;
-  # end
+    # elseif isempty(lb0)
+    #   lb = vHb^(1/ 3); # exact solution for k = 1     
+    # else
+    #   lb = lb0;
+    # end
+    # if !@isdefined(eb)
+    #   eb = 1;
+    # elseif isempty(eb)
+    #   eb = 1;
+    # end
 
-  xb = g/ (eb + g); 
-  xb3 = xb^(1/3); 
-  
-  if isnan(fnget_lb2(lb, xb, xb3, g, vHb, k))
-    info = false;
-  else
-    lb = find_zero(fnget_lb2, lb, [xb, xb3, g, vHb, k]);
+    xb = g / (eb + g)
+    xb3 = xb^(1 / 3)
 
-    #lb, flag, info = fzero(@fnget_lb2, lb, [], xb, xb3, g, vHb, k);
-    if lb < 0 || lb > 1 || isnan(lb)
-      info = false;
+    if isnan(fnget_lb2(lb, xb, xb3, g, vHb, k))
+        info = false
+    else
+        lb = find_zero(fnget_lb2, lb, [xb, xb3, g, vHb, k])
+
+        #lb, flag, info = fzero(@fnget_lb2, lb, [], xb, xb3, g, vHb, k);
+        if lb < 0 || lb > 1 || isnan(lb)
+            info = false
+        end
     end
-  end
-  (lb, info) 
+    (lb, info)
 end
 
 function get_lb2(p)
-  # created 2007/07/26 by Bas Kooijman; modified 2013/08/19, 2015/01/18
-  
-  ## Syntax
-  # [lb info] = <../get_lb2.m *get_lb2*> (p, eb, lb0)
-  
-  ## Description
-  # Obtains scaled length at birth, given the scaled reserve density at birth. 
-  # Like get_lb, but using the shooting method, rather than Newton Raphson
-  #
-  # Input
-  #
-  # * p: 3-vector with parameters: g, k, v_H^b (see below)
-  #  
-  # Output
-  #
-  # * lb: scalar with scaled length at birth 
-  # * info: indicator equals 1 if successful, 0 otherwise
+    # created 2007/07/26 by Bas Kooijman; modified 2013/08/19, 2015/01/18
 
-  ## Remarks
-  # Like <get_lb.html *get_lb*>, but uses a shooting method in 1 variable
+    ## Syntax
+    # [lb info] = <../get_lb2.m *get_lb2*> (p, eb, lb0)
 
-  #  unpack p
-  g = p[1];   # g = [E_G] * v/ kap * {p_Am}, energy investment ratio
-  k = p[2];   # k = k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
-  vHb = p[3]; # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm}
+    ## Description
+    # Obtains scaled length at birth, given the scaled reserve density at birth. 
+    # Like get_lb, but using the shooting method, rather than Newton Raphson
+    #
+    # Input
+    #
+    # * p: 3-vector with parameters: g, k, v_H^b (see below)
+    #  
+    # Output
+    #
+    # * lb: scalar with scaled length at birth 
+    # * info: indicator equals 1 if successful, 0 otherwise
 
-  info = true;
+    ## Remarks
+    # Like <get_lb.html *get_lb*>, but uses a shooting method in 1 variable
 
-  #if !@isdefined(lb0) || k == 1
-    lb = vHb ^ (1/3); # exact solution for k = 1
+    #  unpack p
+    g = p[1]   # g = [E_G] * v/ kap * {p_Am}, energy investment ratio
+    k = p[2]   # k = k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
+    vHb = p[3] # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm}
+
+    info = true
+
+    #if !@isdefined(lb0) || k == 1
+    lb = vHb^(1 / 3) # exact solution for k = 1
     if k == 1
-      return;
+        return
     end
-  # elseif isempty(lb0)
-  #   lb = vHb^(1/ 3); # exact solution for k = 1     
-  # else
-  #   lb = lb0;
-  # end
-  # if !@isdefined(eb)
-    eb = 1;
-  # elseif isempty(eb)
-  #   eb = 1;
-  # end
+    # elseif isempty(lb0)
+    #   lb = vHb^(1/ 3); # exact solution for k = 1     
+    # else
+    #   lb = lb0;
+    # end
+    # if !@isdefined(eb)
+    eb = 1
+    # elseif isempty(eb)
+    #   eb = 1;
+    # end
 
-  xb = g/ (eb + g); 
-  xb3 = xb^(1/3); 
-  
-  if isnan(fnget_lb2(lb, xb, xb3, g, vHb, k))
-    info = false;
-  else
-    lb = find_zero(fnget_lb2, lb, [xb, xb3, g, vHb, k]);
+    xb = g / (eb + g)
+    xb3 = xb^(1 / 3)
 
-    #lb, flag, info = fzero(@fnget_lb2, lb, [], xb, xb3, g, vHb, k);
-    if lb < 0 || lb > 1 || isnan(lb)
-      info = false;
+    if isnan(fnget_lb2(lb, xb, xb3, g, vHb, k))
+        info = false
+    else
+        lb = find_zero(fnget_lb2, lb, [xb, xb3, g, vHb, k])
+
+        #lb, flag, info = fzero(@fnget_lb2, lb, [], xb, xb3, g, vHb, k);
+        if lb < 0 || lb > 1 || isnan(lb)
+            info = false
+        end
     end
-  end
-  (lb, info) 
+    (lb, info)
 end
 
 # subfunctions
 
 function fnget_lb2(lb, p)
-  # f = y(x_b) - y_b = 0; x = g/ (e + g); x_b = g/ (e_b + g)
-  # y(x) = x e_H = x g u_H/ l^3 and y_b = x_b g u_H^b/ l_b^3
-  xb, xb3, g, vHb, k = p
-  tspan = (1e-10, xb)
-  prob = ODEProblem(dget_lb2, 0, tspan, [lb, xb, xb3, g, k])
-  #sol = solve(prob, Tsit5())
-  sol = solve(prob, DP())
-  x = sol.t
-  y = sol.u
-  #[x, y] = ode23s(@dget_lb2, [1e-10, xb], 0, [], lb, xb, xb3, g, k);
-  f = y[end] - xb * g * vHb/ lb^3;
+    # f = y(x_b) - y_b = 0; x = g/ (e + g); x_b = g/ (e_b + g)
+    # y(x) = x e_H = x g u_H/ l^3 and y_b = x_b g u_H^b/ l_b^3
+    xb, xb3, g, vHb, k = p
+    tspan = (1e-10, xb)
+    prob = ODEProblem(dget_lb2, 0, tspan, [lb, xb, xb3, g, k])
+    #sol = solve(prob, Tsit5())
+    sol = solve(prob, DP())
+    x = sol.t
+    y = sol.u
+    #[x, y] = ode23s(@dget_lb2, [1e-10, xb], 0, [], lb, xb, xb3, g, k);
+    f = y[end] - xb * g * vHb / lb^3
 end
 
 function dget_lb2(y, p, x)
-  # y = x e_H; x = g/(g + e)
-  # (x,y): (0,0) -> (xb, xb eHb) 
-  lb, xb, xb3, g, k = p
-  x3 = x^(1/ 3);
-  l = x3/ (xb3/ lb - real(beta0(x, xb))/ 3/ g);
-  dy = l + g - y * (k - x)/ (1 - x) * l/ g/ x;
+    # y = x e_H; x = g/(g + e)
+    # (x,y): (0,0) -> (xb, xb eHb) 
+    lb, xb, xb3, g, k = p
+    x3 = x^(1 / 3)
+    l = x3 / (xb3 / lb - real(beta0(x, xb)) / 3 / g)
+    dy = l + g - y * (k - x) / (1 - x) * l / g / x
 end

--- a/src/animal/get_lp.jl
+++ b/src/animal/get_lp.jl
@@ -3,155 +3,156 @@
 
 ##
 function get_lp(p, f, lb0)
-  # created at 2008/06/04 by Bas Kooijman, 
-  # modified 2014/03/03 Starrlight Augustine, 2015/01/18, 2019/01/29 by Bas Kooijman
-  
-  ## Syntax
-  # [lp, lb, info] = <../get_lp.m *get_lp*> (p, f, lb0)
-  
-  ## Description
-  # Obtains scaled length at puberty at constant food density. 
-  # If scaled length at birth (second input) is not specified, it is computed (using automatic initial estimate); 
-  # If it is specified, however, is it just copied to the (second) output. 
-  # Food density is assumed to be constant. scaled length at puberty is obtained ny integrating over time with even detection
-  #
-  # Input
-  #
-  # * p: 5-vector with parameters: g, k, l_T, v_H^b, v_H^p 
-  # * f: optional scalar with scaled functional responses (default 1)
-  # * lb0: optional scalar with scaled length at birth
-  #
-  #      or optional 2-vector with scaled length, l, and scaled maturity, vH
-  #      for a juvenile that is now exposed to f, but previously at another f
-  #      lb0 should be specified for foetal development
-  #  
-  # Output
-  #
-  # * lp: scalar with scaled length at puberty
-  # * lb: scalar with scaled length at birth
-  # * info: indicator equals 1 if successful, 0 otherwise
-  
-  ## Remarks
-  # Similar to <get_lp1.html *get_lp1*>, which uses root finding, rather than integration
-  # Function <get_lp_foetus.html *get_lp_foetus*> does the same, but then for foetal development. 
+    # created at 2008/06/04 by Bas Kooijman, 
+    # modified 2014/03/03 Starrlight Augustine, 2015/01/18, 2019/01/29 by Bas Kooijman
 
-  ## Example of use
-  # get_lp([.5, .1, .1, .01, .2])
-  
-  # unpack pars
-  g   = p[1]; # -, energy investment ratio
-  k   = p[2]; # k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
-  lT  = p[3]; # scaled heating length {p_T}/[p_M]
-  vHb = p[4]; # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm} = E_H^b/ {p_Am}
-  vHp = p[5]; # v_H^p = U_H^p g^2 kM^3/ (1 - kap) v^2; U_H^p = M_H^p/ {J_EAm} = E_H^p/ {p_Am}
+    ## Syntax
+    # [lp, lb, info] = <../get_lp.m *get_lp*> (p, f, lb0)
 
-  if !@isdefined(f)
-    f = 1; 
-  elseif  isempty(f)
-    f = 1; 
-  end
-  li = f - lT; # -, scaled ultimate length
-  
-  if !@isdefined(lb0)
-      lb0 = [];
-      lb, info = get_lb([g, k, vHb], f);
-  elseif isempty(lb0)
-      lb, info = get_lb([g, k, vHb], f);
-  elseif length(lb0) < 2
-      info = true;
-      lb = lb0;
-  else # for a juvenile of length l and maturity vH
-      l = lb0(1); vH = lb0(2); # juvenile now exposed to f
-      lb, info = get_lb([g, k, vHb], f);
-  end
-  
-  # d/d tau vH = b2 l^2 + b3 l^3 - k vH
-  b3 = 1 / (1 + g / f); 
-  b2 = f - b3 * li;
-  # vH(t) = - a0 - a1 exp(- rB t) - a2 exp(- 2 rB t) - a3 exp(- 3 rB t) +
-  #         + (vHb + a0 + a1 + a2 + a3) exp(-kt)
-  a0 = - (b2 + b3 * li) * li^2/ k; # see get_lp1
-  if vHp > -a0      # vH can only reach -a0
-    lp = [;];
-    info = false;
-    println("Warning in get_lp: maturity at puberty cannot be reached \n");
-    return
-  end
-  
-  if k == 1
-    lp = vHp^(1/3);
-  elseif length(lb0) < 2
-    if f * lb^2 * (g + lb) < vHb * k * (g + f) 
-       lp = [;];
-       info = false;
-       println("Warning in get_lp: maturity does not increase at birth \n");
-    else # compute using integration in maturity
-        cb = ContinuousCallback(event_puberty,terminate_affect!)
-        u0 = [vHb, lb]
-        tspan = (0, 1e8)
-        s_M = 1.0
-        prob = ODEProblem(dget_l_ISO_t, u0, tspan, [k, lT, g, f, s_M, vHp])
-        #sol = solve(prob, Tsit5(), reltol=1e-9, abstol=1e-9, callback=cb)
-        sol = solve(prob, DP5(), reltol=1e-9, abstol=1e-9, callback=cb)
-        t = sol.t
-        vHl = sol.u
-        tp = t[end]
-        vHlp = vHl[end]
-       #options = odeset('Events', @event_puberty); s_M = 1;
-       #[t, vHl, tp, vHlp] = ode45(@dget_l_ISO_t, [0; 1e8], [vHb; lb], options, k, lT, g, f, s_M, vHp);
-        lp = vHlp[2];
+    ## Description
+    # Obtains scaled length at puberty at constant food density. 
+    # If scaled length at birth (second input) is not specified, it is computed (using automatic initial estimate); 
+    # If it is specified, however, is it just copied to the (second) output. 
+    # Food density is assumed to be constant. scaled length at puberty is obtained ny integrating over time with even detection
+    #
+    # Input
+    #
+    # * p: 5-vector with parameters: g, k, l_T, v_H^b, v_H^p 
+    # * f: optional scalar with scaled functional responses (default 1)
+    # * lb0: optional scalar with scaled length at birth
+    #
+    #      or optional 2-vector with scaled length, l, and scaled maturity, vH
+    #      for a juvenile that is now exposed to f, but previously at another f
+    #      lb0 should be specified for foetal development
+    #  
+    # Output
+    #
+    # * lp: scalar with scaled length at puberty
+    # * lb: scalar with scaled length at birth
+    # * info: indicator equals 1 if successful, 0 otherwise
+
+    ## Remarks
+    # Similar to <get_lp1.html *get_lp1*>, which uses root finding, rather than integration
+    # Function <get_lp_foetus.html *get_lp_foetus*> does the same, but then for foetal development. 
+
+    ## Example of use
+    # get_lp([.5, .1, .1, .01, .2])
+
+    # unpack pars
+    g = p[1] # -, energy investment ratio
+    k = p[2] # k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
+    lT = p[3] # scaled heating length {p_T}/[p_M]
+    vHb = p[4] # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm} = E_H^b/ {p_Am}
+    vHp = p[5] # v_H^p = U_H^p g^2 kM^3/ (1 - kap) v^2; U_H^p = M_H^p/ {J_EAm} = E_H^p/ {p_Am}
+
+    if !@isdefined(f)
+        f = 1
+    elseif isempty(f)
+        f = 1
     end
-  else # for a juvenile of length l and maturity vH
-    if f * l^2 * (g + l) < vH * k * (g + f) 
-       lp = [;];
-       info = false;
-       println("Warning in get_lp: maturity does not increase initially \n");
-    elseif vH + 1e-4 < vHp # compute using integration in time
-        u0 = [vH, vHp]
-        tspan = (0, 1e8)
-        s_M = 1.0
-        prob = ODEProblem(dget_l_ISO, u0, l, [k, lT, g, f, s_M]) # this needs finishing
-        #sol = solve(prob, Tsit5(), reltol=1e-9, abstol=1e-9)
-        sol = solve(prob, DP5(), reltol=1e-9, abstol=1e-9)
-      #[vH, lbp] = ode45(@dget_l_ISO, [vH; vHp], l, [], k, lT, g, f, 1); 
-      lp = lbp[end];
-      if lp > 0.8 * f # recompute using integration in time with event
-        cb = ContinuousCallback(event_puberty,terminate_affect!)
-        u0 = [vHb, lb]
-        tspan = (0, 1e8)
-        s_M = 1.0
-        prob = ODEProblem(dget_l_ISO_t, u0, tspan, [k, lT, g, f, s_M, vHp])
-        #sol = solve(prob, Tsit5(), reltol=1e-9, abstol=1e-9, callback=cb)
-        sol = solve(prob, DP5(), reltol=1e-9, abstol=1e-9, callback=cb)
-        t = sol.t
-        vHl = sol.u
-        tp = t[end]
-        vHlp = vHl[end]
-        #options = odeset('Events', @event_puberty); s_M = 1;
-        #[t, vHl, tp, vHlp] = ode45(@dget_l_ISO_t, [0; 1e8], [vHb; lb], options, k, lT, g, f, s_M, vHp);
-        lp = vHlp[2];
-      end    
-    else
-      lp = l;
-      info = false;
-      println("Warning in get_lp: initial maturity exceeds puberty threshold \n")
+    li = f - lT # -, scaled ultimate length
+
+    if !@isdefined(lb0)
+        lb0 = []
+        lb, info = get_lb([g, k, vHb], f)
+    elseif isempty(lb0)
+        lb, info = get_lb([g, k, vHb], f)
+    elseif length(lb0) < 2
+        info = true
+        lb = lb0
+    else # for a juvenile of length l and maturity vH
+        l = lb0(1)
+        vH = lb0(2) # juvenile now exposed to f
+        lb, info = get_lb([g, k, vHb], f)
     end
-  end
-  
-#   if lp > f - 1e-4
-#     println("Warning in get_lp: l_p very close to l_i\n')      
-#   end
-(lp, lb, info)
+
+    # d/d tau vH = b2 l^2 + b3 l^3 - k vH
+    b3 = 1 / (1 + g / f)
+    b2 = f - b3 * li
+    # vH(t) = - a0 - a1 exp(- rB t) - a2 exp(- 2 rB t) - a3 exp(- 3 rB t) +
+    #         + (vHb + a0 + a1 + a2 + a3) exp(-kt)
+    a0 = -(b2 + b3 * li) * li^2 / k # see get_lp1
+    if vHp > -a0      # vH can only reach -a0
+        lp = [;]
+        info = false
+        println("Warning in get_lp: maturity at puberty cannot be reached \n")
+        return
+    end
+
+    if k == 1
+        lp = vHp^(1 / 3)
+    elseif length(lb0) < 2
+        if f * lb^2 * (g + lb) < vHb * k * (g + f)
+            lp = [;]
+            info = false
+            println("Warning in get_lp: maturity does not increase at birth \n")
+        else # compute using integration in maturity
+            cb = ContinuousCallback(event_puberty, terminate_affect!)
+            u0 = [vHb, lb]
+            tspan = (0, 1e8)
+            s_M = 1.0
+            prob = ODEProblem(dget_l_ISO_t, u0, tspan, [k, lT, g, f, s_M, vHp])
+            #sol = solve(prob, Tsit5(), reltol=1e-9, abstol=1e-9, callback=cb)
+            sol = solve(prob, DP5(), reltol = 1e-9, abstol = 1e-9, callback = cb)
+            t = sol.t
+            vHl = sol.u
+            tp = t[end]
+            vHlp = vHl[end]
+            #options = odeset('Events', @event_puberty); s_M = 1;
+            #[t, vHl, tp, vHlp] = ode45(@dget_l_ISO_t, [0; 1e8], [vHb; lb], options, k, lT, g, f, s_M, vHp);
+            lp = vHlp[2]
+        end
+    else # for a juvenile of length l and maturity vH
+        if f * l^2 * (g + l) < vH * k * (g + f)
+            lp = [;]
+            info = false
+            println("Warning in get_lp: maturity does not increase initially \n")
+        elseif vH + 1e-4 < vHp # compute using integration in time
+            u0 = [vH, vHp]
+            tspan = (0, 1e8)
+            s_M = 1.0
+            prob = ODEProblem(dget_l_ISO, u0, l, [k, lT, g, f, s_M]) # this needs finishing
+            #sol = solve(prob, Tsit5(), reltol=1e-9, abstol=1e-9)
+            sol = solve(prob, DP5(), reltol = 1e-9, abstol = 1e-9)
+            #[vH, lbp] = ode45(@dget_l_ISO, [vH; vHp], l, [], k, lT, g, f, 1); 
+            lp = lbp[end]
+            if lp > 0.8 * f # recompute using integration in time with event
+                cb = ContinuousCallback(event_puberty, terminate_affect!)
+                u0 = [vHb, lb]
+                tspan = (0, 1e8)
+                s_M = 1.0
+                prob = ODEProblem(dget_l_ISO_t, u0, tspan, [k, lT, g, f, s_M, vHp])
+                #sol = solve(prob, Tsit5(), reltol=1e-9, abstol=1e-9, callback=cb)
+                sol = solve(prob, DP5(), reltol = 1e-9, abstol = 1e-9, callback = cb)
+                t = sol.t
+                vHl = sol.u
+                tp = t[end]
+                vHlp = vHl[end]
+                #options = odeset('Events', @event_puberty); s_M = 1;
+                #[t, vHl, tp, vHlp] = ode45(@dget_l_ISO_t, [0; 1e8], [vHb; lb], options, k, lT, g, f, s_M, vHp);
+                lp = vHlp[2]
+            end
+        else
+            lp = l
+            info = false
+            println("Warning in get_lp: initial maturity exceeds puberty threshold \n")
+        end
+    end
+
+    #   if lp > f - 1e-4
+    #     println("Warning in get_lp: l_p very close to l_i\n')      
+    #   end
+    (lp, lb, info)
 end
 
 
 function get_lp(p, f)
     # created at 2008/06/04 by Bas Kooijman, 
     # modified 2014/03/03 Starrlight Augustine, 2015/01/18, 2019/01/29 by Bas Kooijman
-    
+
     ## Syntax
     # [lp, lb, info] = <../get_lp.m *get_lp*> (p, f)
-    
+
     ## Description
     # Obtains scaled length at puberty at constant food density. 
     # If scaled length at birth (second input) is not specified, it is computed (using automatic initial estimate); 
@@ -171,31 +172,31 @@ function get_lp(p, f)
     # * lp: scalar with scaled length at puberty
     # * lb: scalar with scaled length at birth
     # * info: indicator equals 1 if successful, 0 otherwise
-    
+
     ## Remarks
     # Similar to <get_lp1.html *get_lp1*>, which uses root finding, rather than integration
     # Function <get_lp_foetus.html *get_lp_foetus*> does the same, but then for foetal development. 
-  
+
     ## Example of use
     # get_lp([.5, .1, .1, .01, .2])
-    
+
     # unpack pars
-    g   = p[1]; # -, energy investment ratio
-    k   = p[2]; # k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
-    lT  = p[3]; # scaled heating length {p_T}/[p_M]
-    vHb = p[4]; # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm} = E_H^b/ {p_Am}
-    vHp = p[5]; # v_H^p = U_H^p g^2 kM^3/ (1 - kap) v^2; U_H^p = M_H^p/ {J_EAm} = E_H^p/ {p_Am}
-  
+    g = p[1] # -, energy investment ratio
+    k = p[2] # k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
+    lT = p[3] # scaled heating length {p_T}/[p_M]
+    vHb = p[4] # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm} = E_H^b/ {p_Am}
+    vHp = p[5] # v_H^p = U_H^p g^2 kM^3/ (1 - kap) v^2; U_H^p = M_H^p/ {J_EAm} = E_H^p/ {p_Am}
+
     if !@isdefined(f)
-      f = 1; 
-    elseif  isempty(f)
-      f = 1; 
+        f = 1
+    elseif isempty(f)
+        f = 1
     end
-    li = f - lT; # -, scaled ultimate length
-    
+    li = f - lT # -, scaled ultimate length
+
     # if !@isdefined(lb0)
     #    lb0 = [];
-        lb, info = get_lb([g, k, vHb], f);
+    lb, info = get_lb([g, k, vHb], f)
     # elseif isempty(lb0)
     #     lb, info = get_lb([g, k, vHb], f);
     # elseif length(lb0) < 2
@@ -205,89 +206,89 @@ function get_lp(p, f)
     #     l = lb0(1); vH = lb0(2); # juvenile now exposed to f
     #     lb, info = get_lb([g, k, vHb], f);
     # end
-    
+
     # d/d tau vH = b2 l^2 + b3 l^3 - k vH
-    b3 = 1 / (1 + g / f); 
-    b2 = f - b3 * li;
+    b3 = 1 / (1 + g / f)
+    b2 = f - b3 * li
     # vH(t) = - a0 - a1 exp(- rB t) - a2 exp(- 2 rB t) - a3 exp(- 3 rB t) +
     #         + (vHb + a0 + a1 + a2 + a3) exp(-kt)
-    a0 = - (b2 + b3 * li) * li^2/ k; # see get_lp1
+    a0 = -(b2 + b3 * li) * li^2 / k # see get_lp1
     if vHp > -a0      # vH can only reach -a0
-      lp = [;];
-      info = false;
-      println("Warning in get_lp: maturity at puberty cannot be reached \n");
-      return
+        lp = [;]
+        info = false
+        println("Warning in get_lp: maturity at puberty cannot be reached \n")
+        return
     end
-    
+
     if k == 1
-      lp = vHp^(1/3);
-    #elseif length(lb0) < 2
+        lp = vHp^(1 / 3)
+        #elseif length(lb0) < 2
     else
-      if f * lb^2 * (g + lb) < vHb * k * (g + f) 
-         lp = [;];
-         info = false;
-         println("Warning in get_lp: maturity does not increase at birth \n");
-      else # compute using integration in maturity
-          cb = ContinuousCallback(event_puberty,terminate_affect!)
-          u0 = [vHb, lb]
-          tspan = (0, 1e8)
-          s_M = 1.0
-          prob = ODEProblem(dget_l_ISO_t, u0, tspan, [k, lT, g, f, s_M, vHp])
-          #sol = solve(prob, Tsit5(), reltol=1e-9, abstol=1e-9, callback=cb)
-          sol = solve(prob, DP5(), reltol=1e-9, abstol=1e-9, callback=cb)
-          t = sol.t
-          vHl = sol.u
-          tp = t[end]
-          vHlp = vHl[end]
-         #options = odeset('Events', @event_puberty); s_M = 1;
-         #[t, vHl, tp, vHlp] = ode45(@dget_l_ISO_t, [0; 1e8], [vHb; lb], options, k, lT, g, f, s_M, vHp);
-          lp = vHlp[2];
-      end
-    # else # for a juvenile of length l and maturity vH
-    #   if f * l^2 * (g + l) < vH * k * (g + f) 
-    #      lp = [;];
-    #      info = false;
-    #      println("Warning in get_lp: maturity does not increase initially \n");
-    #   elseif vH + 1e-4 < vHp # compute using integration in time
-    #       u0 = [vH, vHp]
-    #       tspan = (0, 1e8)
-    #       s_M = 1.0
-    #       prob = ODEProblem(dget_l_ISO, u0, l, [k, lT, g, f, s_M]) # this may be incorrect
-    #       sol = solve(prob, Tsit5(), reltol=1e-9, abstol=1e-9, callback=cb)
-    #     #[vH, lbp] = ode45(@dget_l_ISO, [vH; vHp], l, [], k, lT, g, f, 1); 
-    #     lp = lbp[end];
-    #     if lp > 0.8 * f # recompute using integration in time with event
-    #       cb = ContinuousCallback(event_puberty,terminate_affect!)
-    #       u0 = [vHb, lb]
-    #       tspan = (0, 1e8)
-    #       s_M = 1.0
-    #       prob = ODEProblem(dget_l_ISO_t, u0, tspan, [k, lT, g, f, s_M, vHp])
-    #       sol = solve(prob, Tsit5(), reltol=1e-9, abstol=1e-9, callback=cb)
-    #       t = sol.t
-    #       vHl = sol.u
-    #       tp = t[end]
-    #       vHlp = vHl[end]
-    #       #options = odeset('Events', @event_puberty); s_M = 1;
-    #       #[t, vHl, tp, vHlp] = ode45(@dget_l_ISO_t, [0; 1e8], [vHb; lb], options, k, lT, g, f, s_M, vHp);
-    #       lp = vHlp[2];
-    #     end    
-    #   else
-    #     lp = l;
-    #     info = false;
-    #     println("Warning in get_lp: initial maturity exceeds puberty threshold \n")
-    #   end
+        if f * lb^2 * (g + lb) < vHb * k * (g + f)
+            lp = [;]
+            info = false
+            println("Warning in get_lp: maturity does not increase at birth \n")
+        else # compute using integration in maturity
+            cb = ContinuousCallback(event_puberty, terminate_affect!)
+            u0 = [vHb, lb]
+            tspan = (0, 1e8)
+            s_M = 1.0
+            prob = ODEProblem(dget_l_ISO_t, u0, tspan, [k, lT, g, f, s_M, vHp])
+            #sol = solve(prob, Tsit5(), reltol=1e-9, abstol=1e-9, callback=cb)
+            sol = solve(prob, DP5(), reltol = 1e-9, abstol = 1e-9, callback = cb)
+            t = sol.t
+            vHl = sol.u
+            tp = t[end]
+            vHlp = vHl[end]
+            #options = odeset('Events', @event_puberty); s_M = 1;
+            #[t, vHl, tp, vHlp] = ode45(@dget_l_ISO_t, [0; 1e8], [vHb; lb], options, k, lT, g, f, s_M, vHp);
+            lp = vHlp[2]
+        end
+        # else # for a juvenile of length l and maturity vH
+        #   if f * l^2 * (g + l) < vH * k * (g + f) 
+        #      lp = [;];
+        #      info = false;
+        #      println("Warning in get_lp: maturity does not increase initially \n");
+        #   elseif vH + 1e-4 < vHp # compute using integration in time
+        #       u0 = [vH, vHp]
+        #       tspan = (0, 1e8)
+        #       s_M = 1.0
+        #       prob = ODEProblem(dget_l_ISO, u0, l, [k, lT, g, f, s_M]) # this may be incorrect
+        #       sol = solve(prob, Tsit5(), reltol=1e-9, abstol=1e-9, callback=cb)
+        #     #[vH, lbp] = ode45(@dget_l_ISO, [vH; vHp], l, [], k, lT, g, f, 1); 
+        #     lp = lbp[end];
+        #     if lp > 0.8 * f # recompute using integration in time with event
+        #       cb = ContinuousCallback(event_puberty,terminate_affect!)
+        #       u0 = [vHb, lb]
+        #       tspan = (0, 1e8)
+        #       s_M = 1.0
+        #       prob = ODEProblem(dget_l_ISO_t, u0, tspan, [k, lT, g, f, s_M, vHp])
+        #       sol = solve(prob, Tsit5(), reltol=1e-9, abstol=1e-9, callback=cb)
+        #       t = sol.t
+        #       vHl = sol.u
+        #       tp = t[end]
+        #       vHlp = vHl[end]
+        #       #options = odeset('Events', @event_puberty); s_M = 1;
+        #       #[t, vHl, tp, vHlp] = ode45(@dget_l_ISO_t, [0; 1e8], [vHb; lb], options, k, lT, g, f, s_M, vHp);
+        #       lp = vHlp[2];
+        #     end    
+        #   else
+        #     lp = l;
+        #     info = false;
+        #     println("Warning in get_lp: initial maturity exceeds puberty threshold \n")
+        #   end
     end
-    
-  #   if lp > f - 1e-4
-  #     println("Warning in get_lp: l_p very close to l_i\n')      
-  #   end
-  (lp, lb, info)
-  end
+
+    #   if lp > f - 1e-4
+    #     println("Warning in get_lp: l_p very close to l_i\n')      
+    #   end
+    (lp, lb, info)
+end
 
 function event_puberty(vHl, t, integrator)
     # vHl: 2-vector with [vH; l]
     vHp = integrator.p[6]
     vHp - vHl[1] * (t < 5e5)
-  end
-  
-  terminate_affect!(integrator) = terminate!(integrator)
+end
+
+terminate_affect!(integrator) = terminate!(integrator)

--- a/src/animal/get_tb.jl
+++ b/src/animal/get_tb.jl
@@ -3,129 +3,129 @@
 
 ##
 function get_tb(p, eb, lb)
-  #  created at 2007/07/27 by Bas Kooijman; modified 2014/03/17, 2015/01/18
-  # modified 2018/09/10 (t -> tau) Nina Marn
-  
-  ## Syntax
-  # [tau_b, lb, info] = <../get_tb.m *get_tb*> (p, eb, lb)
-  
-  ## Description
-  # Obtains scaled age at birth, given the scaled reserve density at birth. 
-  # Divide the result by the somatic maintenance rate coefficient to arrive at age at birth. 
-  #
-  # Input
-  #
-  # * p: 1 or 3-vector with parameters g, k_J/ k_M, v_H^b
-  #
-  #     Last 2 values are optional in invoke call to get_lb
-  #
-  # * eb: optional scalar with scaled reserve density at birth (default eb = 1)
-  # * lb: optional scalar with scaled length at birth (default: lb is obtained from get_lb)
-  #  
-  # Output
-  #
-  # * tau_b: scaled age at birth \tau_b = a_b k_M
-  # * lb: scalar with scaled length at birth: L_b/ L_m
-  # * info: indicator equals 1 if successful, 0 otherwise
-  
-  ## Remarks
-  # See also <get_tb1.html *get_tb1*> for backward integration over maturity and
-  # <get_tb_foetus.html *get_tb_foetus*> for foetal development
-  
-  ## Example of use
-  # get_tb([.1;.5;.03])
-  # See also <../mydata_ue0.m *mydata_ue0*>
-   
-  if !@isdefined(eb)
-    eb = 1; # maximum value as juvenile
-  end
+    #  created at 2007/07/27 by Bas Kooijman; modified 2014/03/17, 2015/01/18
+    # modified 2018/09/10 (t -> tau) Nina Marn
 
-  info = true;
-  
-  if !@isdefined(lb)
-    if length(p) < 3
-      println("not enough input parameters, see get_lb \n");
-      tau_b = [];
-      return;
+    ## Syntax
+    # [tau_b, lb, info] = <../get_tb.m *get_tb*> (p, eb, lb)
+
+    ## Description
+    # Obtains scaled age at birth, given the scaled reserve density at birth. 
+    # Divide the result by the somatic maintenance rate coefficient to arrive at age at birth. 
+    #
+    # Input
+    #
+    # * p: 1 or 3-vector with parameters g, k_J/ k_M, v_H^b
+    #
+    #     Last 2 values are optional in invoke call to get_lb
+    #
+    # * eb: optional scalar with scaled reserve density at birth (default eb = 1)
+    # * lb: optional scalar with scaled length at birth (default: lb is obtained from get_lb)
+    #  
+    # Output
+    #
+    # * tau_b: scaled age at birth \tau_b = a_b k_M
+    # * lb: scalar with scaled length at birth: L_b/ L_m
+    # * info: indicator equals 1 if successful, 0 otherwise
+
+    ## Remarks
+    # See also <get_tb1.html *get_tb1*> for backward integration over maturity and
+    # <get_tb_foetus.html *get_tb_foetus*> for foetal development
+
+    ## Example of use
+    # get_tb([.1;.5;.03])
+    # See also <../mydata_ue0.m *mydata_ue0*>
+
+    if !@isdefined(eb)
+        eb = 1 # maximum value as juvenile
     end
-    lb, info = get_lb(p, eb);
-  end
-  if isempty(lb)
-    lb, info = get_lb(p, eb);
-  end
-  lb = get_lb(p, eb)
-  # unpack p
-  g = p[1];  # energy investment ratio
 
-  xb = g/ (eb + g); # f = e_b 
-  ab = 3 * g * xb^(1/ 3)/ lb; # \alpha_b
-  tau_b = 3 * quadgk(x -> dget_tb(x, ab, xb), 1e-15, xb)[1];
-  (tau_b, lb, info)
+    info = true
+
+    if !@isdefined(lb)
+        if length(p) < 3
+            println("not enough input parameters, see get_lb \n")
+            tau_b = []
+            return
+        end
+        lb, info = get_lb(p, eb)
+    end
+    if isempty(lb)
+        lb, info = get_lb(p, eb)
+    end
+    lb = get_lb(p, eb)
+    # unpack p
+    g = p[1]  # energy investment ratio
+
+    xb = g / (eb + g) # f = e_b 
+    ab = 3 * g * xb^(1 / 3) / lb # \alpha_b
+    tau_b = 3 * quadgk(x -> dget_tb(x, ab, xb), 1e-15, xb)[1]
+    (tau_b, lb, info)
 end
 
 function get_tb(p, eb)
-  #  created at 2007/07/27 by Bas Kooijman; modified 2014/03/17, 2015/01/18
-  # modified 2018/09/10 (t -> tau) Nina Marn
-  
-  ## Syntax
-  # [tau_b, lb, info] = <../get_tb.m *get_tb*> (p, eb)
-  
-  ## Description
-  # Obtains scaled age at birth, given the scaled reserve density at birth. 
-  # Divide the result by the somatic maintenance rate coefficient to arrive at age at birth. 
-  #
-  # Input
-  #
-  # * p: 1 or 3-vector with parameters g, k_J/ k_M, v_H^b
-  #
-  #     Last 2 values are optional in invoke call to get_lb
-  #
-  # * eb: optional scalar with scaled reserve density at birth (default eb = 1)
-  #  
-  # Output
-  #
-  # * tau_b: scaled age at birth \tau_b = a_b k_M
-  # * lb: scalar with scaled length at birth: L_b/ L_m
-  # * info: indicator equals 1 if successful, 0 otherwise
-  
-  ## Remarks
-  # See also <get_tb1.html *get_tb1*> for backward integration over maturity and
-  # <get_tb_foetus.html *get_tb_foetus*> for foetal development
-  
-  ## Example of use
-  # get_tb([.1;.5;.03])
-  # See also <../mydata_ue0.m *mydata_ue0*>
-   
-  if !@isdefined(eb)
-    eb = 1; # maximum value as juvenile
-  end
+    #  created at 2007/07/27 by Bas Kooijman; modified 2014/03/17, 2015/01/18
+    # modified 2018/09/10 (t -> tau) Nina Marn
 
-  info = true;
-  
-  # if !@isdefined(lb)
-    if length(p) < 3
-      println("not enough input parameters, see get_lb \n");
-      tau_b = [];
-      return;
+    ## Syntax
+    # [tau_b, lb, info] = <../get_tb.m *get_tb*> (p, eb)
+
+    ## Description
+    # Obtains scaled age at birth, given the scaled reserve density at birth. 
+    # Divide the result by the somatic maintenance rate coefficient to arrive at age at birth. 
+    #
+    # Input
+    #
+    # * p: 1 or 3-vector with parameters g, k_J/ k_M, v_H^b
+    #
+    #     Last 2 values are optional in invoke call to get_lb
+    #
+    # * eb: optional scalar with scaled reserve density at birth (default eb = 1)
+    #  
+    # Output
+    #
+    # * tau_b: scaled age at birth \tau_b = a_b k_M
+    # * lb: scalar with scaled length at birth: L_b/ L_m
+    # * info: indicator equals 1 if successful, 0 otherwise
+
+    ## Remarks
+    # See also <get_tb1.html *get_tb1*> for backward integration over maturity and
+    # <get_tb_foetus.html *get_tb_foetus*> for foetal development
+
+    ## Example of use
+    # get_tb([.1;.5;.03])
+    # See also <../mydata_ue0.m *mydata_ue0*>
+
+    if !@isdefined(eb)
+        eb = 1 # maximum value as juvenile
     end
-    lb, info = get_lb(p, eb);
-  # end
-  # if isempty(lb)
-  #   lb, info = get_lb(p, eb);
-  # end
-  # unpack p
-  g = p[1];  # energy investment ratio
 
-  xb = g/ (eb + g); # f = e_b 
-  ab = 3 * g * xb^(1/ 3)/ lb; # \alpha_b
-  tau_b = 3 * quadgk(x -> dget_tb(x, ab, xb), 1e-15, xb)[1];
-  (tau_b, lb, info)
+    info = true
+
+    # if !@isdefined(lb)
+    if length(p) < 3
+        println("not enough input parameters, see get_lb \n")
+        tau_b = []
+        return
+    end
+    lb, info = get_lb(p, eb)
+    # end
+    # if isempty(lb)
+    #   lb, info = get_lb(p, eb);
+    # end
+    # unpack p
+    g = p[1]  # energy investment ratio
+
+    xb = g / (eb + g) # f = e_b 
+    ab = 3 * g * xb^(1 / 3) / lb # \alpha_b
+    tau_b = 3 * quadgk(x -> dget_tb(x, ab, xb), 1e-15, xb)[1]
+    (tau_b, lb, info)
 end
 
 # subfunction
 
 function dget_tb(x, ab, xb)
-  # called by get_tb
+    # called by get_tb
 
-  f = x .^ (-2/ 3) ./ (1 - x) ./ (ab - real(beta0(x, xb)));
+    f = x .^ (-2 / 3) ./ (1 - x) ./ (ab - real(beta0(x, xb)))
 end

--- a/src/animal/get_tm_s.jl
+++ b/src/animal/get_tm_s.jl
@@ -3,122 +3,127 @@
 
 ##
 function get_tm_s(p, f, lb, lp)
-  # created 2009/02/21 by Bas Kooijman, modified 2014/03/17, 2015/01/18
-  
-  ## Syntax
-  # [tm, Sb, Sp, info] = <../get_tm_s.m *get_tm_s*>(p, f, lb, lp)
-  
-  ## Description
-  # Obtains scaled mean age at death assuming a short growth period relative to the life span
-  # Divide the result by the somatic maintenance rate coefficient to arrive at the mean age at death. 
-  # The variant get_tm_foetus does the same in case of foetal development.
-  # If the input parameter vector has only 4 elements (for [g, lT, ha/ kM2, sG]), 
-  #   it skips the calulation of the survival probability at birth and puberty.   
-  #
-  # Input
-  #
-  # * p: 4 or 7-vector with parameters: [g lT ha sG] or [g k lT vHb vHp ha SG]
-  # * f: optional scalar with scaled reserve density at birth (default eb = 1)
-  # * lb: optional scalar with scaled length at birth (default: lb is obtained from get_lb)
-  # * lp: optional scalar with scaled length at puberty
-  #  
-  # Output
-  #
-  # * tm: scalar with scaled mean life span
-  # * Sb: scalar with survival probability at birth (if length p = 7)
-  # * Sp: scalar with survival prabability at puberty (if length p = 7)
-  # * info: indicator equals 1 if successful, 0 otherwise
-  
-  ## Remarks
-  # Obsolete function; please use get_tm_mod.
-  # Theory is given in comments on DEB3 Section 6.1.1. 
-  # See <get_tm.html *get_tm*> for the general case of long growth period relative to life span
+    # created 2009/02/21 by Bas Kooijman, modified 2014/03/17, 2015/01/18
 
-  ## Example of use
-  # get_tm_s([.5, .1, .1, .01, .2, .1, .01])
-  
-  if !@isdefined(f)
-    f = 1; # maximum value as juvenile
-  end
+    ## Syntax
+    # [tm, Sb, Sp, info] = <../get_tm_s.m *get_tm_s*>(p, f, lb, lp)
 
-  if length(p) >= 7
-    #  unpack pars
-    g   = p[1]; # energy investment ratio
-    #k   = p(2); # k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
-    lT  = p[3]; # scaled heating length {p_T}/[p_M]Lm
-    #vHb = p(4); # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_B^b = M_H^b/ {J_EAm}
-    #vHp = p(5); # v_H^p = U_H^p g^2 kM^3/ (1 - kap) v^2; U_B^p = M_H^p/ {J_EAm}
-    ha  = p[6]; # h_a/ k_M^2, scaled Weibull aging acceleration
-    sG  = p[7]; # Gompertz stress coefficient
-    
-  elseif length(p) == 4
-    #  unpack pars
-    g   = p[1]; # energy investment ratio
-    lT  = p[2]; # scaled heating length {p_T}/[p_M]Lm
-    ha  = p[3]; # h_a/ k_M^2, scaled Weibull aging acceleration
-    sG  = p[4]; # Gompertz stress coefficient
-  end
+    ## Description
+    # Obtains scaled mean age at death assuming a short growth period relative to the life span
+    # Divide the result by the somatic maintenance rate coefficient to arrive at the mean age at death. 
+    # The variant get_tm_foetus does the same in case of foetal development.
+    # If the input parameter vector has only 4 elements (for [g, lT, ha/ kM2, sG]), 
+    #   it skips the calulation of the survival probability at birth and puberty.   
+    #
+    # Input
+    #
+    # * p: 4 or 7-vector with parameters: [g lT ha sG] or [g k lT vHb vHp ha SG]
+    # * f: optional scalar with scaled reserve density at birth (default eb = 1)
+    # * lb: optional scalar with scaled length at birth (default: lb is obtained from get_lb)
+    # * lp: optional scalar with scaled length at puberty
+    #  
+    # Output
+    #
+    # * tm: scalar with scaled mean life span
+    # * Sb: scalar with survival probability at birth (if length p = 7)
+    # * Sp: scalar with survival prabability at puberty (if length p = 7)
+    # * info: indicator equals 1 if successful, 0 otherwise
 
-  if abs(sG) < 1e-10
-    sG = 1e-10;
-  end
-  
-  li = f - lT;
-  hW3 = ha * f * g/ 6/ li; hW = hW3^(1/3); # scaled Weibull aging rate
-  hG = sG * f * g * li^2;  hG3 = hG^3;     # scaled Gompertz aging rate
-  tG = hG/ hW; tG3 = hG3/ hW3;             # scaled Gompertz aging rate
+    ## Remarks
+    # Obsolete function; please use get_tm_mod.
+    # Theory is given in comments on DEB3 Section 6.1.1. 
+    # See <get_tm.html *get_tm*> for the general case of long growth period relative to life span
 
-  info_lp = 1;
-  if length(p) >= 7
-    if !@isdefined(lp) && !@isdefined(lb) 
-      lp, lb, info_lp = get_lp(p, f);
-    elseif !@isdefined(lp) || isempty(lp) # fix this
-      lp, lb, info_lp = get_lp(p, f, lb);
+    ## Example of use
+    # get_tm_s([.5, .1, .1, .01, .2, .1, .01])
+
+    if !@isdefined(f)
+        f = 1 # maximum value as juvenile
     end
 
-    # get scaled age at birth, puberty: tb, tp
-    tb, lb, info_tb = get_tb(p, f, lb);
-    irB = 3 * (1 + f/ g);
-    tp = tb + irB * log((li - lb)/ (li - lp));
-    hGtb = hG * tb;
-    Sb = exp((1 - exp(hGtb) + hGtb + hGtb^2/ 2) * 6/ tG3); 
-    hGtp = hG * tp;
-    Sp = exp((1 - exp(hGtp) + hGtp + hGtp^2/ 2) * 6/ tG3); 
-    if info_lp == 1 && info_tb == 1
-      info = 1;
-    else
-      info = false;
-    end
-  else # length(p) == 4
-    Sb = NaN; Sp = NaN; info = 1;
-  end
-  
-  if abs(sG) < 1e-10
-    tm = gamma(4/3)/ hW;
-    tm_tail = 0;
-  elseif hG > 0
-    tm = 10/ hG; # upper boundary for main integration of S(t)
-    tm_tail = expint(exp(tm * hG) * 6/ tG3)/ hG;
-    tm = (quadgk(x -> fnget_tm_s(x, tG), 0, tm*hW)[1]/ hW)[1] + tm_tail;
-    #tau_b = 3 * quadgk(x -> dget_tb(x, ab, xb), 1e-15, xb)[1];
-    #tm = quad(@fnget_tm_s, 0, tm * hW, [], [], tG)/ hW + tm_tail;
+    if length(p) >= 7
+        #  unpack pars
+        g = p[1] # energy investment ratio
+        #k   = p(2); # k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
+        lT = p[3] # scaled heating length {p_T}/[p_M]Lm
+        #vHb = p(4); # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_B^b = M_H^b/ {J_EAm}
+        #vHp = p(5); # v_H^p = U_H^p g^2 kM^3/ (1 - kap) v^2; U_B^p = M_H^p/ {J_EAm}
+        ha = p[6] # h_a/ k_M^2, scaled Weibull aging acceleration
+        sG = p[7] # Gompertz stress coefficient
 
-  else # hG < 0
-    tm = -1e4/ hG; # upper boundary for main integration of S(t)
-    hw = hW * sqrt( - 3/ tG); # scaled hW
-    tm_tail = sqrt(pi)* erfc(tm * hw)/ 2/ hw;
-    tm = (quadgk(x -> fnget_tm_s(x, tG), 0, tm*hW)[1]/ hW)[1] + tm_tail;
-    #tm = quad(@fnget_tm_s, 0, tm * hW, [], [], tG)/ hW + tm_tail;
-  end
-  (tm, Sb, Sp, info)
+    elseif length(p) == 4
+        #  unpack pars
+        g = p[1] # energy investment ratio
+        lT = p[2] # scaled heating length {p_T}/[p_M]Lm
+        ha = p[3] # h_a/ k_M^2, scaled Weibull aging acceleration
+        sG = p[4] # Gompertz stress coefficient
+    end
+
+    if abs(sG) < 1e-10
+        sG = 1e-10
+    end
+
+    li = f - lT
+    hW3 = ha * f * g / 6 / li
+    hW = hW3^(1 / 3) # scaled Weibull aging rate
+    hG = sG * f * g * li^2
+    hG3 = hG^3     # scaled Gompertz aging rate
+    tG = hG / hW
+    tG3 = hG3 / hW3             # scaled Gompertz aging rate
+
+    info_lp = 1
+    if length(p) >= 7
+        if !@isdefined(lp) && !@isdefined(lb)
+            lp, lb, info_lp = get_lp(p, f)
+        elseif !@isdefined(lp) || isempty(lp) # fix this
+            lp, lb, info_lp = get_lp(p, f, lb)
+        end
+
+        # get scaled age at birth, puberty: tb, tp
+        tb, lb, info_tb = get_tb(p, f, lb)
+        irB = 3 * (1 + f / g)
+        tp = tb + irB * log((li - lb) / (li - lp))
+        hGtb = hG * tb
+        Sb = exp((1 - exp(hGtb) + hGtb + hGtb^2 / 2) * 6 / tG3)
+        hGtp = hG * tp
+        Sp = exp((1 - exp(hGtp) + hGtp + hGtp^2 / 2) * 6 / tG3)
+        if info_lp == 1 && info_tb == 1
+            info = 1
+        else
+            info = false
+        end
+    else # length(p) == 4
+        Sb = NaN
+        Sp = NaN
+        info = 1
+    end
+
+    if abs(sG) < 1e-10
+        tm = gamma(4 / 3) / hW
+        tm_tail = 0
+    elseif hG > 0
+        tm = 10 / hG # upper boundary for main integration of S(t)
+        tm_tail = expint(exp(tm * hG) * 6 / tG3) / hG
+        tm = (quadgk(x -> fnget_tm_s(x, tG), 0, tm * hW)[1]/hW)[1] + tm_tail
+        #tau_b = 3 * quadgk(x -> dget_tb(x, ab, xb), 1e-15, xb)[1];
+        #tm = quad(@fnget_tm_s, 0, tm * hW, [], [], tG)/ hW + tm_tail;
+
+    else # hG < 0
+        tm = -1e4 / hG # upper boundary for main integration of S(t)
+        hw = hW * sqrt(-3 / tG) # scaled hW
+        tm_tail = sqrt(pi) * erfc(tm * hw) / 2 / hw
+        tm = (quadgk(x -> fnget_tm_s(x, tG), 0, tm * hW)[1]/hW)[1] + tm_tail
+        #tm = quad(@fnget_tm_s, 0, tm * hW, [], [], tG)/ hW + tm_tail;
+    end
+    (tm, Sb, Sp, info)
 end
 
 function get_tm_s(p, f, lb)
     # created 2009/02/21 by Bas Kooijman, modified 2014/03/17, 2015/01/18
-    
+
     ## Syntax
     # [tm, Sb, Sp, info] = <../get_tm_s.m *get_tm_s*>(p, f, lb)
-    
+
     ## Description
     # Obtains scaled mean age at death assuming a short growth period relative to the life span
     # Divide the result by the somatic maintenance rate coefficient to arrive at the mean age at death. 
@@ -138,105 +143,114 @@ function get_tm_s(p, f, lb)
     # * Sb: scalar with survival probability at birth (if length p = 7)
     # * Sp: scalar with survival prabability at puberty (if length p = 7)
     # * info: indicator equals 1 if successful, 0 otherwise
-    
+
     ## Remarks
     # Obsolete function; please use get_tm_mod.
     # Theory is given in comments on DEB3 Section 6.1.1. 
     # See <get_tm.html *get_tm*> for the general case of long growth period relative to life span
-  
+
     ## Example of use
     # get_tm_s([.5, .1, .1, .01, .2, .1, .01])
-    
+
     if !@isdefined(f)
-      f = 1; # maximum value as juvenile
+        f = 1 # maximum value as juvenile
     end
-  
+
     if length(p) >= 7
-      #  unpack pars
-      g   = p[1]; # energy investment ratio
-      #k   = p(2); # k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
-      lT  = p[3]; # scaled heating length {p_T}/[p_M]Lm
-      #vHb = p(4); # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_B^b = M_H^b/ {J_EAm}
-      #vHp = p(5); # v_H^p = U_H^p g^2 kM^3/ (1 - kap) v^2; U_B^p = M_H^p/ {J_EAm}
-      ha  = p[6]; # h_a/ k_M^2, scaled Weibull aging acceleration
-      sG  = p[7]; # Gompertz stress coefficient
-      
+        #  unpack pars
+        g = p[1] # energy investment ratio
+        #k   = p(2); # k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
+        lT = p[3] # scaled heating length {p_T}/[p_M]Lm
+        #vHb = p(4); # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_B^b = M_H^b/ {J_EAm}
+        #vHp = p(5); # v_H^p = U_H^p g^2 kM^3/ (1 - kap) v^2; U_B^p = M_H^p/ {J_EAm}
+        ha = p[6] # h_a/ k_M^2, scaled Weibull aging acceleration
+        sG = p[7] # Gompertz stress coefficient
+
     elseif length(p) == 4
-      #  unpack pars
-      g   = p[1]; # energy investment ratio
-      lT  = p[2]; # scaled heating length {p_T}/[p_M]Lm
-      ha  = p[3]; # h_a/ k_M^2, scaled Weibull aging acceleration
-      sG  = p[4]; # Gompertz stress coefficient
+        #  unpack pars
+        g = p[1] # energy investment ratio
+        lT = p[2] # scaled heating length {p_T}/[p_M]Lm
+        ha = p[3] # h_a/ k_M^2, scaled Weibull aging acceleration
+        sG = p[4] # Gompertz stress coefficient
     end
-  
+
     if abs(sG) < 1e-10
-      sG = 1e-10;
+        sG = 1e-10
     end
-    
-    li = f - lT;
-    hW3 = ha * f * g/ 6/ li; hW = hW3^(1/3); # scaled Weibull aging rate
-    hG = sG * f * g * li^2;  hG3 = hG^3;     # scaled Gompertz aging rate
-    tG = hG/ hW; tG3 = hG3/ hW3;             # scaled Gompertz aging rate
-  
-    info_lp = 1;
+
+    li = f - lT
+    hW3 = ha * f * g / 6 / li
+    hW = hW3^(1 / 3) # scaled Weibull aging rate
+    hG = sG * f * g * li^2
+    hG3 = hG^3     # scaled Gompertz aging rate
+    tG = hG / hW
+    tG3 = hG3 / hW3             # scaled Gompertz aging rate
+
+    info_lp = 1
     if length(p) >= 7
-      if !@isdefined(lp) && !@isdefined(lb) 
-        lp, lb, info_lp = get_lp(p, f);
-      elseif !@isdefined(lp) || isempty(lp) # fix this
-        lp, lb, info_lp = get_lp(p, f, lb);
-      end
-  
-      # get scaled age at birth, puberty: tb, tp
-      tb, lb, info_tb = get_tb(p, f, lb);
-      irB = 3 * (1 + f/ g);
-      tp = tb + irB * log((li - lb)/ (li - lp));
-      hGtb = hG * tb;
-      Sb = exp((1 - exp(hGtb) + hGtb + hGtb^2/ 2) * 6/ tG3); 
-      hGtp = hG * tp;
-      Sp = exp((1 - exp(hGtp) + hGtp + hGtp^2/ 2) * 6/ tG3); 
-      if info_lp == 1 && info_tb == 1
-        info = 1;
-      else
-        info = false;
-      end
+        if !@isdefined(lp) && !@isdefined(lb)
+            lp, lb, info_lp = get_lp(p, f)
+        elseif !@isdefined(lp) || isempty(lp) # fix this
+            lp, lb, info_lp = get_lp(p, f, lb)
+        end
+
+        # get scaled age at birth, puberty: tb, tp
+        tb, lb, info_tb = get_tb(p, f, lb)
+        irB = 3 * (1 + f / g)
+        tp = tb + irB * log((li - lb) / (li - lp))
+        hGtb = hG * tb
+        Sb = exp((1 - exp(hGtb) + hGtb + hGtb^2 / 2) * 6 / tG3)
+        hGtp = hG * tp
+        Sp = exp((1 - exp(hGtp) + hGtp + hGtp^2 / 2) * 6 / tG3)
+        if info_lp == 1 && info_tb == 1
+            info = 1
+        else
+            info = false
+        end
     else # length(p) == 4
-      Sb = NaN; Sp = NaN; info = 1;
+        Sb = NaN
+        Sp = NaN
+        info = 1
     end
-    
+
     if abs(sG) < 1e-10
-      tm = gamma(4/3)/ hW;
-      tm_tail = 0;
+        tm = gamma(4 / 3) / hW
+        tm_tail = 0
     elseif hG > 0
-      tm = 10/ hG; # upper boundary for main integration of S(t)
-      tm_tail = expint(exp(tm * hG) * 6/ tG3)/ hG;
- tm = (quadgk(x -> fnget_tm_s(x*hW, tG), 0, tm*hW)[1])[1] + tm_tail;
-      #tm = quad(@fnget_tm_s, 0, tm * hW, [], [], tG)/ hW + tm_tail;
-  
+        tm = 10 / hG # upper boundary for main integration of S(t)
+        tm_tail = expint(exp(tm * hG) * 6 / tG3) / hG
+        tm = (quadgk(x -> fnget_tm_s(x * hW, tG), 0, tm * hW)[1])[1] + tm_tail
+        #tm = quad(@fnget_tm_s, 0, tm * hW, [], [], tG)/ hW + tm_tail;
+
     else # hG < 0
-      tm = -1e4/ hG; # upper boundary for main integration of S(t)
-      hw = hW * sqrt( - 3/ tG); # scaled hW
-      tm_tail = sqrt(pi)* erfc(tm * hw)/ 2/ hw;
-      tm = (quadgk(x -> fnget_tm_s(x*hW, tG), 0, tm*hW)[1])[1] + tm_tail;
-      #tm = quad(@fnget_tm_s, 0, tm * hW, [], [], tG)/ hW + tm_tail;
+        tm = -1e4 / hG # upper boundary for main integration of S(t)
+        hw = hW * sqrt(-3 / tG) # scaled hW
+        tm_tail = sqrt(pi) * erfc(tm * hw) / 2 / hw
+        tm = (quadgk(x -> fnget_tm_s(x * hW, tG), 0, tm * hW)[1])[1] + tm_tail
+        #tm = quad(@fnget_tm_s, 0, tm * hW, [], [], tG)/ hW + tm_tail;
     end
     (tm, Sb, Sp, info)
-  end
+end
 
 # subfunction
 
 function fnget_tm_s(t, tG)
-# modified 2010/02/25
-# called by get_tm_s for life span at short growth periods
-# integrate ageing surv prob over scaled age
-# t: age * hW 
-# S: ageing survival prob
+    # modified 2010/02/25
+    # called by get_tm_s for life span at short growth periods
+    # integrate ageing surv prob over scaled age
+    # t: age * hW 
+    # S: ageing survival prob
 
-hGt = tG * t; # age * hG
-if tG > 0
-# Compute the scaled dataset
- S = exp.(-(1 .+ sum(cumprod((hGt .* (1 ./ (4:500)))', dims=2), dims=2))' .* t.^3)
-# S= exp.((-(1 .+ byrow(byrow(Dataset(hGt' .* (1 ./ (4:500)'), :auto), cumprod), sum))' .* t.^3)');
-else # tG < 0
- S = exp.((((1 .+ hGt .+ hGt.^2/ 2)  - exp.(hGt)) * 6/ tG^3)'); 
-end
+    hGt = tG * t # age * hG
+    if tG > 0
+        # Compute the scaled dataset
+        S =
+            exp.(
+                -(1 .+ sum(cumprod((hGt .* (1 ./ (4:500)))', dims = 2), dims = 2))' .*
+                t .^ 3
+            )
+        # S= exp.((-(1 .+ byrow(byrow(Dataset(hGt' .* (1 ./ (4:500)'), :auto), cumprod), sum))' .* t.^3)');
+    else # tG < 0
+        S = exp.((((1 .+ hGt .+ hGt .^ 2 / 2) - exp.(hGt)) * 6 / tG^3)')
+    end
 end

--- a/src/animal/get_tp.jl
+++ b/src/animal/get_tp.jl
@@ -3,235 +3,239 @@
 
 ##
 function get_tp(p, f, lb0)
-  # created at 2008/06/04 by Bas Kooijman, 
-  # modified 2014/03/04 Starrlight Augustine, 2015/01/18 Bas Kooijman
-  # modified 2018/09/10 (t -> tau) Nina Marn
-  # modified 2021/11/24 Bas Kooijman
-  
-  ## Syntax
-  # [tau_p, tau_b, lp, lb, info] = <../get_tp.m *get_tp*>(p, f, lb0)
-  
-  ## Description
-  # Obtains scaled age at puberty.
-  # Food density is assumed to be constant.
-  # Multiply the result with the somatic maintenance rate coefficient to arrive at age at puberty. 
-  #
-  # Input
-  #
-  # * p: 5-vector with parameters: g, k, l_T, v_H^b, v_H^p 
-  # * f: optional scalar with functional response (default f = 1)
-  # * lb0: optional scalar with scaled length at birth
-  #
-  #      or optional 2-vector with scaled length, l, and scaled maturity, vH
-  #      for a juvenile that is now exposed to f, but previously at another f
-  #
-  # Output
-  #
-  # * tau_p: scaled with age at puberty \tau_p = a_p k_M
-  #
-  #      if length(lb0)==2, tp is the scaled time till puberty
-  #
-  # * tau_b: scaled with age at birth \tau_b = a_b k_M
-  # * lp: scaler length at puberty
-  # * lb: scaler length at birth
-  # * info: indicator equals 1 if successful
-  
-  ## Remarks
-  # Function <get_tp_foetus.html *get_tp_foetus*> does the same for foetal development; the result depends on embryonal development. 
+    # created at 2008/06/04 by Bas Kooijman, 
+    # modified 2014/03/04 Starrlight Augustine, 2015/01/18 Bas Kooijman
+    # modified 2018/09/10 (t -> tau) Nina Marn
+    # modified 2021/11/24 Bas Kooijman
 
-  ## Example of use
-  # get_tp([.5, .1, .1, .01, .2])
+    ## Syntax
+    # [tau_p, tau_b, lp, lb, info] = <../get_tp.m *get_tp*>(p, f, lb0)
 
-  #  unpack pars
-  g   = p[1]; # energy investment ratio
-  k   = p[2]; # k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
-  lT  = p[3]; # scaled heating length {p_T}/[p_M]Lm
-  vHb = p[4]; # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm} = E_H^b/ {p_Am}
-  vHp = p[5]; # v_H^p = U_H^p g^2 kM^3/ (1 - kap) v^2; U_H^p = M_H^p/ {J_EAm} = E_H^p/ {p_Am}
+    ## Description
+    # Obtains scaled age at puberty.
+    # Food density is assumed to be constant.
+    # Multiply the result with the somatic maintenance rate coefficient to arrive at age at puberty. 
+    #
+    # Input
+    #
+    # * p: 5-vector with parameters: g, k, l_T, v_H^b, v_H^p 
+    # * f: optional scalar with functional response (default f = 1)
+    # * lb0: optional scalar with scaled length at birth
+    #
+    #      or optional 2-vector with scaled length, l, and scaled maturity, vH
+    #      for a juvenile that is now exposed to f, but previously at another f
+    #
+    # Output
+    #
+    # * tau_p: scaled with age at puberty \tau_p = a_p k_M
+    #
+    #      if length(lb0)==2, tp is the scaled time till puberty
+    #
+    # * tau_b: scaled with age at birth \tau_b = a_b k_M
+    # * lp: scaler length at puberty
+    # * lb: scaler length at birth
+    # * info: indicator equals 1 if successful
 
-  if !@isdefined(f)
-    f = 1;
-  elseif isempty(f)
-    f = 1;
-  end
-  if !@isdefined(lb0)
-    lb0 = [;];
-  end
+    ## Remarks
+    # Function <get_tp_foetus.html *get_tp_foetus*> does the same for foetal development; the result depends on embryonal development. 
 
-  if vHp < vHb
-    println("Warning from get_tp: vHp < vHb\n")
-    tau_b, l_b = get_tb(p([1 2 4]), f);
-    tau_p = [;]; l_p = [;];
-    info = false;
-    return
-  end
+    ## Example of use
+    # get_tp([.5, .1, .1, .01, .2])
 
-  if k == 1 && f * (f - lT)^2 > vHp * k
-    lb = vHb^(1/3); 
-    tau_b = get_tb(p([1 2 4]), f, lb);
-    lp = vHp^(1/3);
-    li = f - lT;
-    rB = 1 / 3/ (1 + f/g);
-    tau_p = tau_b + log((li - lb)/ (li - lp))/ rB;
-    info = true;
-  elseif f * (f - lT)^2 <= vHp * k # reproduction is not possible
-    pars_lb = p[1 2 4];
-    tau_b, lb = get_tb(pars_lb, f); 
-    tau_p = 1e20; # tau_p is never reached
-    lp = 1;    # lp is never reached
-    info = false;
-  else # reproduction is possible
-    if length(lb0) != 2 # lb0 = l_b 
-      tau_b, lb, info = get_tb([g, k, vHb], f)
-      cb = ContinuousCallback(event_puberty_tp,terminate_affect_tp!)
-      u0 = [vHb, lb]
-      tspan = (0, 1e8)
-      s_M = 1.0
-      prob = ODEProblem(dget_l_ISO_t, u0, tspan, [k, lT, g, f, s_M, vHp])
-      #sol = solve(prob, Tsit5(), reltol=1e-9, abstol=1e-9, callback=cb)
-      sol = solve(prob, DP5(), reltol=1e-9, abstol=1e-9, callback=cb)
-      t = sol.t
-      vHl = sol.u
-      tp = t[end]
-      vHlp = vHl[end]
-      #options = odeset('Events',@event_puberty, 'NonNegative',ones(2,1), 'AbsTol',1e-9, 'RelTol',1e-9); s_M = 1;
-      #[t, vHl, tp, vHlp] = ode45(@dget_l_ISO_t, [0; 1e8], [vHb; lb], options, k, lT, g, f, s_M, vHp);
-      tau_p = tau_b + tp; lp = vHlp[2];
+    #  unpack pars
+    g = p[1] # energy investment ratio
+    k = p[2] # k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
+    lT = p[3] # scaled heating length {p_T}/[p_M]Lm
+    vHb = p[4] # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm} = E_H^b/ {p_Am}
+    vHp = p[5] # v_H^p = U_H^p g^2 kM^3/ (1 - kap) v^2; U_H^p = M_H^p/ {J_EAm} = E_H^p/ {p_Am}
 
-    else # lb0 = l and t for a juvenile
-      tau_b = NaN;
-      #[lp, lb, info] = get_lp(p, f, lb0);
-      l = lb0(1);
-      li = f - lT;
-      irB = 3 * (1 + f/ g); # k_M/ r_B
-      tau_p = irB * log((li - l)/ (li - lp));
+    if !@isdefined(f)
+        f = 1
+    elseif isempty(f)
+        f = 1
     end
-  end
- 
-  if !isreal(tau_p) # tp must be real and positive
-      info = false;
-  elseif tau_p < 0
-      info = false;
-  end
-  (tau_p, tau_b, lp, lb, info)
+    if !@isdefined(lb0)
+        lb0 = [;]
+    end
+
+    if vHp < vHb
+        println("Warning from get_tp: vHp < vHb\n")
+        tau_b, l_b = get_tb(p([1 2 4]), f)
+        tau_p = [;]
+        l_p = [;]
+        info = false
+        return
+    end
+
+    if k == 1 && f * (f - lT)^2 > vHp * k
+        lb = vHb^(1 / 3)
+        tau_b = get_tb(p([1 2 4]), f, lb)
+        lp = vHp^(1 / 3)
+        li = f - lT
+        rB = 1 / 3 / (1 + f / g)
+        tau_p = tau_b + log((li - lb) / (li - lp)) / rB
+        info = true
+    elseif f * (f - lT)^2 <= vHp * k # reproduction is not possible
+        pars_lb = p[1 2 4]
+        tau_b, lb = get_tb(pars_lb, f)
+        tau_p = 1e20 # tau_p is never reached
+        lp = 1    # lp is never reached
+        info = false
+    else # reproduction is possible
+        if length(lb0) != 2 # lb0 = l_b 
+            tau_b, lb, info = get_tb([g, k, vHb], f)
+            cb = ContinuousCallback(event_puberty_tp, terminate_affect_tp!)
+            u0 = [vHb, lb]
+            tspan = (0, 1e8)
+            s_M = 1.0
+            prob = ODEProblem(dget_l_ISO_t, u0, tspan, [k, lT, g, f, s_M, vHp])
+            #sol = solve(prob, Tsit5(), reltol=1e-9, abstol=1e-9, callback=cb)
+            sol = solve(prob, DP5(), reltol = 1e-9, abstol = 1e-9, callback = cb)
+            t = sol.t
+            vHl = sol.u
+            tp = t[end]
+            vHlp = vHl[end]
+            #options = odeset('Events',@event_puberty, 'NonNegative',ones(2,1), 'AbsTol',1e-9, 'RelTol',1e-9); s_M = 1;
+            #[t, vHl, tp, vHlp] = ode45(@dget_l_ISO_t, [0; 1e8], [vHb; lb], options, k, lT, g, f, s_M, vHp);
+            tau_p = tau_b + tp
+            lp = vHlp[2]
+
+        else # lb0 = l and t for a juvenile
+            tau_b = NaN
+            #[lp, lb, info] = get_lp(p, f, lb0);
+            l = lb0(1)
+            li = f - lT
+            irB = 3 * (1 + f / g) # k_M/ r_B
+            tau_p = irB * log((li - l) / (li - lp))
+        end
+    end
+
+    if !isreal(tau_p) # tp must be real and positive
+        info = false
+    elseif tau_p < 0
+        info = false
+    end
+    (tau_p, tau_b, lp, lb, info)
 end
 
 function get_tp(p, f)
-  # created at 2008/06/04 by Bas Kooijman, 
-  # modified 2014/03/04 Starrlight Augustine, 2015/01/18 Bas Kooijman
-  # modified 2018/09/10 (t -> tau) Nina Marn
-  # modified 2021/11/24 Bas Kooijman
-  
-  ## Syntax
-  # [tau_p, tau_b, lp, lb, info] = <../get_tp.m *get_tp*>(p, f)
-  
-  ## Description
-  # Obtains scaled age at puberty.
-  # Food density is assumed to be constant.
-  # Multiply the result with the somatic maintenance rate coefficient to arrive at age at puberty. 
-  #
-  # Input
-  #
-  # * p: 5-vector with parameters: g, k, l_T, v_H^b, v_H^p 
-  # * f: optional scalar with functional response (default f = 1)
-  #
-  #      or optional 2-vector with scaled length, l, and scaled maturity, vH
-  #      for a juvenile that is now exposed to f, but previously at another f
-  #
-  # Output
-  #
-  # * tau_p: scaled with age at puberty \tau_p = a_p k_M
-  #
-  #
-  # * tau_b: scaled with age at birth \tau_b = a_b k_M
-  # * lp: scaler length at puberty
-  # * lb: scaler length at birth
-  # * info: indicator equals 1 if successful
-  
-  ## Remarks
-  # Function <get_tp_foetus.html *get_tp_foetus*> does the same for foetal development; the result depends on embryonal development. 
+    # created at 2008/06/04 by Bas Kooijman, 
+    # modified 2014/03/04 Starrlight Augustine, 2015/01/18 Bas Kooijman
+    # modified 2018/09/10 (t -> tau) Nina Marn
+    # modified 2021/11/24 Bas Kooijman
 
-  ## Example of use
-  # get_tp([.5, .1, .1, .01, .2])
+    ## Syntax
+    # [tau_p, tau_b, lp, lb, info] = <../get_tp.m *get_tp*>(p, f)
 
-  #  unpack pars
-  g   = p[1]; # energy investment ratio
-  k   = p[2]; # k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
-  lT  = p[3]; # scaled heating length {p_T}/[p_M]Lm
-  vHb = p[4]; # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm} = E_H^b/ {p_Am}
-  vHp = p[5]; # v_H^p = U_H^p g^2 kM^3/ (1 - kap) v^2; U_H^p = M_H^p/ {J_EAm} = E_H^p/ {p_Am}
+    ## Description
+    # Obtains scaled age at puberty.
+    # Food density is assumed to be constant.
+    # Multiply the result with the somatic maintenance rate coefficient to arrive at age at puberty. 
+    #
+    # Input
+    #
+    # * p: 5-vector with parameters: g, k, l_T, v_H^b, v_H^p 
+    # * f: optional scalar with functional response (default f = 1)
+    #
+    #      or optional 2-vector with scaled length, l, and scaled maturity, vH
+    #      for a juvenile that is now exposed to f, but previously at another f
+    #
+    # Output
+    #
+    # * tau_p: scaled with age at puberty \tau_p = a_p k_M
+    #
+    #
+    # * tau_b: scaled with age at birth \tau_b = a_b k_M
+    # * lp: scaler length at puberty
+    # * lb: scaler length at birth
+    # * info: indicator equals 1 if successful
 
-  if !@isdefined(f)
-    f = 1;
-  elseif isempty(f)
-    f = 1;
-  end
-  # if !@isdefined(lb0)
-  #   lb0 = [;];
-  # end
+    ## Remarks
+    # Function <get_tp_foetus.html *get_tp_foetus*> does the same for foetal development; the result depends on embryonal development. 
 
-  if vHp < vHb
-    println("Warning from get_tp: vHp < vHb\n")
-    tau_b, l_b = get_tb(p([1 2 4]), f);
-    tau_p = [;]; l_p = [;];
-    info = false;
-    return
-  end
+    ## Example of use
+    # get_tp([.5, .1, .1, .01, .2])
 
-  if k == 1 && f * (f - lT)^2 > vHp * k
-    lb = vHb^(1/3); 
-    tau_b = get_tb(p([1 2 4]), f, lb);
-    lp = vHp^(1/3);
-    li = f - lT;
-    rB = 1 / 3/ (1 + f/g);
-    tau_p = tau_b + log((li - lb)/ (li - lp))/ rB;
-    info = true;
-  elseif f * (f - lT)^2 <= vHp * k # reproduction is not possible
-    pars_lb = p[1 2 4];
-    tau_b, lb = get_tb(pars_lb, f); 
-    tau_p = 1e20; # tau_p is never reached
-    lp = 1;    # lp is never reached
-    info = false;
-  else # reproduction is possible
-    #if length(lb0) != 2 # lb0 = l_b 
-      tau_b, lb, info = get_tb([g, k, vHb], f)
-      cb = ContinuousCallback(event_puberty_tp,terminate_affect_tp!)
-      u0 = [vHb, lb]
-      tspan = (0, 1e8)
-      s_M = 1.0
-      prob = ODEProblem(dget_l_ISO_t, u0, tspan, [k, lT, g, f, s_M, vHp])
-      #sol = solve(prob, Tsit5(), reltol=1e-9, abstol=1e-9, callback=cb)
-      sol = solve(prob, DP5(), reltol=1e-9, abstol=1e-9, callback=cb)
-      t = sol.t
-      vHl = sol.u
-      tp = t[end]
-      vHlp = vHl[end]
-      #options = odeset('Events',@event_puberty, 'NonNegative',ones(2,1), 'AbsTol',1e-9, 'RelTol',1e-9); s_M = 1;
-      #[t, vHl, tp, vHlp] = ode45(@dget_l_ISO_t, [0; 1e8], [vHb; lb], options, k, lT, g, f, s_M, vHp);
-      tau_p = tau_b + tp; lp = vHlp[2];
+    #  unpack pars
+    g = p[1] # energy investment ratio
+    k = p[2] # k_J/ k_M, ratio of maturity and somatic maintenance rate coeff
+    lT = p[3] # scaled heating length {p_T}/[p_M]Lm
+    vHb = p[4] # v_H^b = U_H^b g^2 kM^3/ (1 - kap) v^2; U_H^b = M_H^b/ {J_EAm} = E_H^b/ {p_Am}
+    vHp = p[5] # v_H^p = U_H^p g^2 kM^3/ (1 - kap) v^2; U_H^p = M_H^p/ {J_EAm} = E_H^p/ {p_Am}
 
-    # else # lb0 = l and t for a juvenile
-    #   tau_b = NaN;
-    #   #[lp, lb, info] = get_lp(p, f, lb0);
-    #   l = lb0(1);
-    #   li = f - lT;
-    #   irB = 3 * (1 + f/ g); # k_M/ r_B
-    #   tau_p = irB * log((li - l)/ (li - lp));
+    if !@isdefined(f)
+        f = 1
+    elseif isempty(f)
+        f = 1
+    end
+    # if !@isdefined(lb0)
+    #   lb0 = [;];
     # end
-  end
- 
-  if !isreal(tau_p) # tp must be real and positive
-      info = false;
-  elseif tau_p < 0
-      info = false;
-  end
-  (tau_p, tau_b, lp, lb, info)
+
+    if vHp < vHb
+        println("Warning from get_tp: vHp < vHb\n")
+        tau_b, l_b = get_tb(p([1 2 4]), f)
+        tau_p = [;]
+        l_p = [;]
+        info = false
+        return
+    end
+
+    if k == 1 && f * (f - lT)^2 > vHp * k
+        lb = vHb^(1 / 3)
+        tau_b = get_tb(p([1 2 4]), f, lb)
+        lp = vHp^(1 / 3)
+        li = f - lT
+        rB = 1 / 3 / (1 + f / g)
+        tau_p = tau_b + log((li - lb) / (li - lp)) / rB
+        info = true
+    elseif f * (f - lT)^2 <= vHp * k # reproduction is not possible
+        pars_lb = p[1 2 4]
+        tau_b, lb = get_tb(pars_lb, f)
+        tau_p = 1e20 # tau_p is never reached
+        lp = 1    # lp is never reached
+        info = false
+    else # reproduction is possible
+        #if length(lb0) != 2 # lb0 = l_b 
+        tau_b, lb, info = get_tb([g, k, vHb], f)
+        cb = ContinuousCallback(event_puberty_tp, terminate_affect_tp!)
+        u0 = [vHb, lb]
+        tspan = (0, 1e8)
+        s_M = 1.0
+        prob = ODEProblem(dget_l_ISO_t, u0, tspan, [k, lT, g, f, s_M, vHp])
+        #sol = solve(prob, Tsit5(), reltol=1e-9, abstol=1e-9, callback=cb)
+        sol = solve(prob, DP5(), reltol = 1e-9, abstol = 1e-9, callback = cb)
+        t = sol.t
+        vHl = sol.u
+        tp = t[end]
+        vHlp = vHl[end]
+        #options = odeset('Events',@event_puberty, 'NonNegative',ones(2,1), 'AbsTol',1e-9, 'RelTol',1e-9); s_M = 1;
+        #[t, vHl, tp, vHlp] = ode45(@dget_l_ISO_t, [0; 1e8], [vHb; lb], options, k, lT, g, f, s_M, vHp);
+        tau_p = tau_b + tp
+        lp = vHlp[2]
+
+        # else # lb0 = l and t for a juvenile
+        #   tau_b = NaN;
+        #   #[lp, lb, info] = get_lp(p, f, lb0);
+        #   l = lb0(1);
+        #   li = f - lT;
+        #   irB = 3 * (1 + f/ g); # k_M/ r_B
+        #   tau_p = irB * log((li - l)/ (li - lp));
+        # end
+    end
+
+    if !isreal(tau_p) # tp must be real and positive
+        info = false
+    elseif tau_p < 0
+        info = false
+    end
+    (tau_p, tau_b, lp, lb, info)
 end
 
 function event_puberty_tp(vHl, t, integrator)
-  # vHl: 2-vector with [vH; l]
-  vHp = integrator.p[6]
-  vHp - vHl[1]
+    # vHl: 2-vector with [vH; l]
+    vHp = integrator.p[6]
+    vHp - vHl[1]
 end
 
 terminate_affect_tp!(integrator) = terminate!(integrator)

--- a/src/animal/get_ue0.jl
+++ b/src/animal/get_ue0.jl
@@ -3,60 +3,61 @@
 
 ##
 function get_ue0(p, eb, lb0)
-  # created at 2007/07/27 by Bas Kooijman; modified 2010/05/02
-  
-  ## Syntax
-  # [uE0, lb, info] = <../get_ue0.m *get_ue0*>(p, eb, lb0)
-  
-  ## Description
-  # Obtains the initial scaled reserve given the scaled reserve density at birth. 
-  # Function get_ue0 does so for eggs, get_ue0_foetus for foetuses. 
-  # Specification of length at birth as third input by-passes its computation, 
-  #   so if you want to specify an initial value for this quantity, you should use get_lb directly. 
-  #
-  # Input
-  #
-  # * p: 1 or 3 -vector with parameters g, k_J/ k_M, v_H^b, see get_lb
-  # * eb: optional scalar with scaled reserbe density at birth 
-  #   (default: eb = 1)
-  # * lb0: optional scalar with scaled length at birth 
-  #   (default: lb is optained from get_lb)
-  #
-  # Output
-  #
-  # * uE0: scaled with scaled reserve at t=0: $U_E^0 g^2 k_M^3/ v^2$ 
-  #   with $U_E^0 = M_E^0/ \{J_{EAm}\}$
-  # * lb: scalar with scaled length at birth
-  # * info: indicator equals 1 if successful, 0 otherwise
-  
-  ## Remarks
-  # See <get_ue0_foetus.html *get_ue0_foetus*> for foetal development.
-  # See <initial_scaled_reserve.html *initial_scaled_reserve*>, for a non-dimensionless scaling.
-  
-  ## Example of use
-  # see <../mydata_ue0.m *mydata_ue0*>
-    
-  if !@isdefined(eb)
-    eb = 1; # maximum value as juvenile
-  end
+    # created at 2007/07/27 by Bas Kooijman; modified 2010/05/02
 
-#  if exist('lb0','var') == 0
-#     if length(p) < 3
-#       println("not enough input parameters, see get_lb \n");
-#       uE0 = [;]; lb = [;]; info = false;
-#       return;
-#     end
-#     lb, info = get_lb(p, eb);
-#   else
-    lb = lb0; info = true;
-#  end
+    ## Syntax
+    # [uE0, lb, info] = <../get_ue0.m *get_ue0*>(p, eb, lb0)
 
-  # unpack p
-  g = p[1];  # energy investment ratio
+    ## Description
+    # Obtains the initial scaled reserve given the scaled reserve density at birth. 
+    # Function get_ue0 does so for eggs, get_ue0_foetus for foetuses. 
+    # Specification of length at birth as third input by-passes its computation, 
+    #   so if you want to specify an initial value for this quantity, you should use get_lb directly. 
+    #
+    # Input
+    #
+    # * p: 1 or 3 -vector with parameters g, k_J/ k_M, v_H^b, see get_lb
+    # * eb: optional scalar with scaled reserbe density at birth 
+    #   (default: eb = 1)
+    # * lb0: optional scalar with scaled length at birth 
+    #   (default: lb is optained from get_lb)
+    #
+    # Output
+    #
+    # * uE0: scaled with scaled reserve at t=0: $U_E^0 g^2 k_M^3/ v^2$ 
+    #   with $U_E^0 = M_E^0/ \{J_{EAm}\}$
+    # * lb: scalar with scaled length at birth
+    # * info: indicator equals 1 if successful, 0 otherwise
 
-  xb = g/ (eb + g);
-  uE0 = (3 * g/ (3 * g * xb^(1/ 3)/ lb - real(beta0(0, xb))))^3;
-  (uE0, lb, info)
+    ## Remarks
+    # See <get_ue0_foetus.html *get_ue0_foetus*> for foetal development.
+    # See <initial_scaled_reserve.html *initial_scaled_reserve*>, for a non-dimensionless scaling.
+
+    ## Example of use
+    # see <../mydata_ue0.m *mydata_ue0*>
+
+    if !@isdefined(eb)
+        eb = 1 # maximum value as juvenile
+    end
+
+    #  if exist('lb0','var') == 0
+    #     if length(p) < 3
+    #       println("not enough input parameters, see get_lb \n");
+    #       uE0 = [;]; lb = [;]; info = false;
+    #       return;
+    #     end
+    #     lb, info = get_lb(p, eb);
+    #   else
+    lb = lb0
+    info = true
+    #  end
+
+    # unpack p
+    g = p[1]  # energy investment ratio
+
+    xb = g / (eb + g)
+    uE0 = (3 * g / (3 * g * xb^(1 / 3) / lb - real(beta0(0, xb))))^3
+    (uE0, lb, info)
 end
 
 ## get_ue0
@@ -65,10 +66,10 @@ end
 ##
 function get_ue0(p, eb)
     # created at 2007/07/27 by Bas Kooijman; modified 2010/05/02
-    
+
     ## Syntax
     # [uE0, lb, info] = <../get_ue0.m *get_ue0*>(p, eb)
-    
+
     ## Description
     # Obtains the initial scaled reserve given the scaled reserve density at birth. 
     # Function get_ue0 does so for eggs, get_ue0_foetus for foetuses. 
@@ -88,33 +89,35 @@ function get_ue0(p, eb)
     #   with $U_E^0 = M_E^0/ \{J_{EAm}\}$
     # * lb: scalar with scaled length at birth
     # * info: indicator equals 1 if successful, 0 otherwise
-    
+
     ## Remarks
     # See <get_ue0_foetus.html *get_ue0_foetus*> for foetal development.
     # See <initial_scaled_reserve.html *initial_scaled_reserve*>, for a non-dimensionless scaling.
-    
+
     ## Example of use
     # see <../mydata_ue0.m *mydata_ue0*>
-      
+
     if !@isdefined(eb)
-      eb = 1; # maximum value as juvenile
+        eb = 1 # maximum value as juvenile
     end
-  
+
     #if exist('lb0','var') == 0
     if length(p) < 3
-        println("not enough input parameters, see get_lb \n");
-        uE0 = [;]; lb = [;]; info = false;
-        return;
+        println("not enough input parameters, see get_lb \n")
+        uE0 = [;]
+        lb = [;]
+        info = false
+        return
     end
-      lb, info = get_lb(p, eb);
+    lb, info = get_lb(p, eb)
     # else
     #   lb = lb0; info = true;
     # end
-  
+
     # unpack p
-    g = p[1];  # energy investment ratio
-  
-    xb = g/ (eb + g);
-    uE0 = (3 * g/ (3 * g * xb^(1/ 3)/ lb - real(beta0(0, xb))))^3;
+    g = p[1]  # energy investment ratio
+
+    xb = g / (eb + g)
+    uE0 = (3 * g / (3 * g * xb^(1 / 3) / lb - real(beta0(0, xb))))^3
     (uE0, lb, info)
-  end
+end

--- a/src/animal/initial_scaled_reserve.jl
+++ b/src/animal/initial_scaled_reserve.jl
@@ -3,65 +3,68 @@
 
 ##
 function initial_scaled_reserve(f, p, Lb0)
-  #  created 2007/08/06 by Bas Kooyman; modified 2009/09/29
-  
-  ## Syntax
-  # [U0, Lb, info] = <../initial_scaled_reserve.m *initial_scaled_reserve*>(f, p, Lb0)
-  
-  ## Description
-  # Gets initial scaled reserve
-  #
-  # Input
-  #
-  # * f: n-vector with scaled functional responses
-  # * p: 5-vector with parameters: VHb, g, kJ, kM, v
-  # * Lb0: optional n-vector with lengths at birth
-  #
-  # Output
-  #
-  # * U0: n-vector with initial scaled reserve: M_E^0/ {J_EAm} or E^0/ {p_Am}
-  # * Lb: n-vector with length at birth
-  # * info: n-vector with 1's if successful, 0's otherwise
-  
-  ## Remarks
-  # Like <get_ue0.html *get_ue0*>, but allows for vector arguments and
-  # input and output is not downscaled to dimensionless quantities,
-  
-  ## Example of use 
-  # p = [.8 .42 1.7 1.7 3.24 .012]; initial_scaled_reserve(1,p)
-  
-  #  unpack parameters
-  VHb = p[1]; # d mm^2, scaled maturity at birth: M_H^b/((1-kap){J_EAm})
-  g   = p[2]; # -, energy investment ratio
-  kJ  = p[3]; # 1/d, maturity maintenance rate coefficient
-  kM  = p[4]; # 1/d, somatic maintenance rate coefficient
-  v   = p[5]; # mm/d, energy conductance
-  
-  # if kJ = kM: VHb = g * Lb^3/ v;
+    #  created 2007/08/06 by Bas Kooyman; modified 2009/09/29
 
-  nf = length(f); U0 = zeros(nf,1)Unitful.d*Unitful.cm^2; Lb = zeros(nf,1)Unitful.cm; info = zeros(nf,1);
-  q = [g, kJ/ kM, VHb * g^2 * kM^3/ v^2];
-  #if exist('Lb0','var') == 1
-    lb0 = ones(nf,1) .* Lb0 * kM * g/ v;
-  #else
-  #  lb0 = ones(nf,1) * get_lb(q,f[1])[1]; # initial estimate for scaled length
-  #end
-  for i = 1:nf
-    lb, info[i] = get_lb(q, f[i], lb0[i]);
-    ## try get_lb1 or get_lb2 for higher accuracy
-    Lb[i] = lb * v/ kM/ g;
-    uE0 = get_ue0(q, f[i], lb);
-    U0[i] = uE0 * v^2/ g^2/ kM^3;
-  end
-  (U0, Lb, info)
+    ## Syntax
+    # [U0, Lb, info] = <../initial_scaled_reserve.m *initial_scaled_reserve*>(f, p, Lb0)
+
+    ## Description
+    # Gets initial scaled reserve
+    #
+    # Input
+    #
+    # * f: n-vector with scaled functional responses
+    # * p: 5-vector with parameters: VHb, g, kJ, kM, v
+    # * Lb0: optional n-vector with lengths at birth
+    #
+    # Output
+    #
+    # * U0: n-vector with initial scaled reserve: M_E^0/ {J_EAm} or E^0/ {p_Am}
+    # * Lb: n-vector with length at birth
+    # * info: n-vector with 1's if successful, 0's otherwise
+
+    ## Remarks
+    # Like <get_ue0.html *get_ue0*>, but allows for vector arguments and
+    # input and output is not downscaled to dimensionless quantities,
+
+    ## Example of use 
+    # p = [.8 .42 1.7 1.7 3.24 .012]; initial_scaled_reserve(1,p)
+
+    #  unpack parameters
+    VHb = p[1] # d mm^2, scaled maturity at birth: M_H^b/((1-kap){J_EAm})
+    g = p[2] # -, energy investment ratio
+    kJ = p[3] # 1/d, maturity maintenance rate coefficient
+    kM = p[4] # 1/d, somatic maintenance rate coefficient
+    v = p[5] # mm/d, energy conductance
+
+    # if kJ = kM: VHb = g * Lb^3/ v;
+
+    nf = length(f)
+    U0 = zeros(nf, 1)Unitful.d * Unitful.cm^2
+    Lb = zeros(nf, 1)Unitful.cm
+    info = zeros(nf, 1)
+    q = [g, kJ / kM, VHb * g^2 * kM^3 / v^2]
+    #if exist('Lb0','var') == 1
+    lb0 = ones(nf, 1) .* Lb0 * kM * g / v
+    #else
+    #  lb0 = ones(nf,1) * get_lb(q,f[1])[1]; # initial estimate for scaled length
+    #end
+    for i = 1:nf
+        lb, info[i] = get_lb(q, f[i], lb0[i])
+        ## try get_lb1 or get_lb2 for higher accuracy
+        Lb[i] = lb * v / kM / g
+        uE0 = get_ue0(q, f[i], lb)
+        U0[i] = uE0 * v^2 / g^2 / kM^3
+    end
+    (U0, Lb, info)
 end
 
 function initial_scaled_reserve(f, p)
     #  created 2007/08/06 by Bas Kooyman; modified 2009/09/29
-    
+
     ## Syntax
     # [U0, Lb, info] = <../initial_scaled_reserve.m *initial_scaled_reserve*>(f, p)
-    
+
     ## Description
     # Gets initial scaled reserve
     #
@@ -75,36 +78,39 @@ function initial_scaled_reserve(f, p)
     # * U0: n-vector with initial scaled reserve: M_E^0/ {J_EAm} or E^0/ {p_Am}
     # * Lb: n-vector with length at birth
     # * info: n-vector with 1's if successful, 0's otherwise
-    
+
     ## Remarks
     # Like <get_ue0.html *get_ue0*>, but allows for vector arguments and
     # input and output is not downscaled to dimensionless quantities,
-    
+
     ## Example of use 
     # p = [.8 .42 1.7 1.7 3.24 .012]; initial_scaled_reserve(1,p)
-    
+
     #  unpack parameters
-    VHb = p[1]; # d mm^2, scaled maturity at birth: M_H^b/((1-kap){J_EAm})
-    g   = p[2]; # -, energy investment ratio
-    kJ  = p[3]; # 1/d, maturity maintenance rate coefficient
-    kM  = p[4]; # 1/d, somatic maintenance rate coefficient
-    v   = p[5]; # mm/d, energy conductance
-    
+    VHb = p[1] # d mm^2, scaled maturity at birth: M_H^b/((1-kap){J_EAm})
+    g = p[2] # -, energy investment ratio
+    kJ = p[3] # 1/d, maturity maintenance rate coefficient
+    kM = p[4] # 1/d, somatic maintenance rate coefficient
+    v = p[5] # mm/d, energy conductance
+
     # if kJ = kM: VHb = g * Lb^3/ v;
-  
-    nf = length(f); U0 = zeros(nf,1)Unitful.d*Unitful.cm^2; Lb = zeros(nf,1)Unitful.cm; info = zeros(nf,1);
-    q = [g, kJ/ kM, VHb * g^2 * kM^3/ v^2];
+
+    nf = length(f)
+    U0 = zeros(nf, 1)Unitful.d * Unitful.cm^2
+    Lb = zeros(nf, 1)Unitful.cm
+    info = zeros(nf, 1)
+    q = [g, kJ / kM, VHb * g^2 * kM^3 / v^2]
     #if exist('Lb0','var') == 1
     #  lb0 = ones(nf,1) .* Lb0 * kM * g/ v;
     #else
-      lb0 = ones(nf,1) * get_lb(q,f[1])[1]; # initial estimate for scaled length
+    lb0 = ones(nf, 1) * get_lb(q, f[1])[1] # initial estimate for scaled length
     #end
     for i = 1:nf
-      lb, info[i] = get_lb(q, f[i]);
-      ## try get_lb1 or get_lb2 for higher accuracy
-      Lb[i] = lb * v/ kM/ g;
-      uE0 = get_ue0(q, f[i], lb)[1];
-      U0[i] = uE0 * v^2/ g^2/ kM^3;
+        lb, info[i] = get_lb(q, f[i])
+        ## try get_lb1 or get_lb2 for higher accuracy
+        Lb[i] = lb * v / kM / g
+        uE0 = get_ue0(q, f[i], lb)[1]
+        U0[i] = uE0 * v^2 / g^2 / kM^3
     end
     (U0, Lb, info)
-  end
+end

--- a/src/animal/reprod_rate.jl
+++ b/src/animal/reprod_rate.jl
@@ -3,116 +3,134 @@
 
 ##
 function reprod_rate(L, f, p, Lf)
-  # created 2003/03/18 by Bas Kooijman, modified 2014/02/26
-  # modified 2018/09/10 (fixed typos in description) Nina Marn
-  
-  ## Syntax
-  # [R, UE0, Lb, Lp, info] = <reprod_rate.m *reprod_rate*>(L, f, p, Lf)
-  
-  ## Description
-  # Calculates the reproduction rate in number of eggs per time
-  # for an individual of length L and scaled reserve density f
-  #
-  # Input
-  #
-  # * L: n-vector with length
-  # * f: scalar with functional response
-  # * p: 9-vector with parameters: kap, kapR, g, kJ, kM, LT, v, UHb, UHp
-  # * Lf: optional scalar with length at birth (initial value only)
-  #
-  #     or optional 2-vector with length, L, and scaled functional response f0
-  #     for a juvenile that is now exposed to f, but previously at another f
-  #  
-  # Output
-  #
-  # * R: n-vector with reproduction rates
-  # * UE0: scalar with scaled initial reserve
-  # * Lb: scalar with (volumetric) length at birth
-  # * Lp: scalar with (volumetric) length at puberty
-  # * info: indicator with 1 for success, 0 otherwise
-  
-  ## Remarks
-  # See also <reprod_rate_foetus.html *reprod_rate_foetus*>, 
-  #   <reprod_rate_j.html *reprod_rate_j*>, <reprod_rate_s.html *reprod_rate_s*>.
-  # For cumulative reproduction, see <cum_reprod.html *cum_reprod*>,
-   #  <cum_reprod_j.html *cum_reprod_j*>, <cum_reprod_s.html *cum_reprod_s*>
-  
-  ## Example of use
-  # See <mydata_reprod_rate.m *mydata_reprod_rate*>
-  
-  #  Explanation of variables:
-  #  R = kapR * pR/ E0
-  #  pR = (1 - kap) pC - kJ * EHp
-  #  [pC] = [Em] (v/ L + kM (1 + LT/L)) f g/ (f + g); pC = [pC] L^3
-  #  [Em] = {pAm}/ v
-  # 
-  #  remove energies; now in lengths, time only
-  # 
-  #  U0 = E0/{pAm}; UHp = EHp/{pAm}; SC = pC/{pAm}; SR = pR/{pAm}
-  #  R = kapR SR/ U0
-  #  SR = (1 - kap) SC - kJ * UHp
-  #  SC = f (g/ L + (1 + LT/L)/ Lm)/ (f + g); Lm = v/ (kM g)
-  #
-  # unpack parameters; parameter sequence, cf get_pars_r
+    # created 2003/03/18 by Bas Kooijman, modified 2014/02/26
+    # modified 2018/09/10 (fixed typos in description) Nina Marn
 
-  kap = p[1]; kapR = p[2]; g = p[3]; kJ = p[4]; kM = p[5];
-  LT = p[6]; v = p[7]; UHb = p[8]; UHp = p[9];
+    ## Syntax
+    # [R, UE0, Lb, Lp, info] = <reprod_rate.m *reprod_rate*>(L, f, p, Lf)
 
-  Lm = v/ (kM * g); # maximum length
-  k = kJ/ kM;       # -, maintenance ratio
-  VHb = UHb/ (1 - kap); VHp = UHp/ (1 - kap);
-  vHb = VHb * g^2 * kM^3/ v^2; vHp = VHp * g^2 * kM^3/ v^2; 
+    ## Description
+    # Calculates the reproduction rate in number of eggs per time
+    # for an individual of length L and scaled reserve density f
+    #
+    # Input
+    #
+    # * L: n-vector with length
+    # * f: scalar with functional response
+    # * p: 9-vector with parameters: kap, kapR, g, kJ, kM, LT, v, UHb, UHp
+    # * Lf: optional scalar with length at birth (initial value only)
+    #
+    #     or optional 2-vector with length, L, and scaled functional response f0
+    #     for a juvenile that is now exposed to f, but previously at another f
+    #  
+    # Output
+    #
+    # * R: n-vector with reproduction rates
+    # * UE0: scalar with scaled initial reserve
+    # * Lb: scalar with (volumetric) length at birth
+    # * Lp: scalar with (volumetric) length at puberty
+    # * info: indicator with 1 for success, 0 otherwise
 
-  p_lb = [g k vHb];             # pars for get_lb
-  p_lp = [g k LT/ Lm vHb vHp]; # pars for get_tp
-  p_UE0 = [VHb g kJ kM v];     # pars for initial_scaled_reserve  
-  p_mat = [kap kapR g kJ kM LT v UHb UHp]; # pars for maturity
+    ## Remarks
+    # See also <reprod_rate_foetus.html *reprod_rate_foetus*>, 
+    #   <reprod_rate_j.html *reprod_rate_j*>, <reprod_rate_s.html *reprod_rate_s*>.
+    # For cumulative reproduction, see <cum_reprod.html *cum_reprod*>,
+    #  <cum_reprod_j.html *cum_reprod_j*>, <cum_reprod_s.html *cum_reprod_s*>
 
-  if !@isdefined Lf
-    Lf = [;];
-  end
+    ## Example of use
+    # See <mydata_reprod_rate.m *mydata_reprod_rate*>
 
-  if length(Lf) <= 1
-    lb0 = Lf/ Lm; # scaled length at birth
-    lp, lb, info_lp = get_lp(p_lp, f, lb0);
-    Lb = lb * Lm; Lp = lp * Lm; # structural length at birth, puberty
-    if info_lp != 1 # return at failure for tp
-      #fprintf('lp could not be obtained in reprod_rate \n')
-      R = L * 0; UE0 = [;];  Lb = [;]; Lp = [;]; info = info_lp;
-      return;
+    #  Explanation of variables:
+    #  R = kapR * pR/ E0
+    #  pR = (1 - kap) pC - kJ * EHp
+    #  [pC] = [Em] (v/ L + kM (1 + LT/L)) f g/ (f + g); pC = [pC] L^3
+    #  [Em] = {pAm}/ v
+    # 
+    #  remove energies; now in lengths, time only
+    # 
+    #  U0 = E0/{pAm}; UHp = EHp/{pAm}; SC = pC/{pAm}; SR = pR/{pAm}
+    #  R = kapR SR/ U0
+    #  SR = (1 - kap) SC - kJ * UHp
+    #  SC = f (g/ L + (1 + LT/L)/ Lm)/ (f + g); Lm = v/ (kM g)
+    #
+    # unpack parameters; parameter sequence, cf get_pars_r
+
+    kap = p[1]
+    kapR = p[2]
+    g = p[3]
+    kJ = p[4]
+    kM = p[5]
+    LT = p[6]
+    v = p[7]
+    UHb = p[8]
+    UHp = p[9]
+
+    Lm = v / (kM * g) # maximum length
+    k = kJ / kM       # -, maintenance ratio
+    VHb = UHb / (1 - kap)
+    VHp = UHp / (1 - kap)
+    vHb = VHb * g^2 * kM^3 / v^2
+    vHp = VHp * g^2 * kM^3 / v^2
+
+    p_lb = [g k vHb]             # pars for get_lb
+    p_lp = [g k LT / Lm vHb vHp] # pars for get_tp
+    p_UE0 = [VHb g kJ kM v]     # pars for initial_scaled_reserve  
+    p_mat = [kap kapR g kJ kM LT v UHb UHp] # pars for maturity
+
+    if !@isdefined Lf
+        Lf = [;]
     end
-  else # if length Lb0 = 2
-    L0 = Lf(1); # cm, structural length at time 0
-    f0 = Lf(2); # -, scaled func response before time 0
-    UH0, a, info_mat = maturity(L0, f0, p_mat);  # d.cm^2, maturity at zero
-    if info_mat != 1# return at failure for tp
-      println("maturity could not be obtained in reprod_rate \n")
-      R = L * 0; UE0 = []; Lb = []; Lp = []; info = info_mat;
-      return;
-    end
-    lp, lb, info_lp = get_lp(p_lp, f);
-    Lb = lb * Lm;
-    u0 = [0, L0]
-    tspan = (UH0, UHp)
-    prob = ODEProblem(dget_l_ISO, u0, tspan, [f, g, v, kap, kJ, Lm, LT]) # this needs finishing
-    #[UH, tL] = ode45(@dget_tL, [UH0; UHp], [0; L0], [], f, g, v, kap, kJ, Lm, LT); 
-    Lp = tL[end][2];  # cm, struc length at puberty after time 0
-  end
 
-  UE0, Lb, info = initial_scaled_reserve(f, p_UE0, Lb);
-  SC = f * L.^3 .* (g ./ L + (1 + LT ./ L)/ Lm)/ (f + g);
-  SR = (1 - kap) * SC - kJ * UHp;
-  R = (L >= Lp) * kapR .* SR/ UE0; # set reprod rate of juveniles to zero
-  (R, UE0, Lb, Lp, info) 
+    if length(Lf) <= 1
+        lb0 = Lf / Lm # scaled length at birth
+        lp, lb, info_lp = get_lp(p_lp, f, lb0)
+        Lb = lb * Lm
+        Lp = lp * Lm # structural length at birth, puberty
+        if info_lp != 1 # return at failure for tp
+            #fprintf('lp could not be obtained in reprod_rate \n')
+            R = L * 0
+            UE0 = [;]
+            Lb = [;]
+            Lp = [;]
+            info = info_lp
+            return
+        end
+    else # if length Lb0 = 2
+        L0 = Lf(1) # cm, structural length at time 0
+        f0 = Lf(2) # -, scaled func response before time 0
+        UH0, a, info_mat = maturity(L0, f0, p_mat)  # d.cm^2, maturity at zero
+        if info_mat != 1# return at failure for tp
+            println("maturity could not be obtained in reprod_rate \n")
+            R = L * 0
+            UE0 = []
+            Lb = []
+            Lp = []
+            info = info_mat
+            return
+        end
+        lp, lb, info_lp = get_lp(p_lp, f)
+        Lb = lb * Lm
+        u0 = [0, L0]
+        tspan = (UH0, UHp)
+        prob = ODEProblem(dget_l_ISO, u0, tspan, [f, g, v, kap, kJ, Lm, LT]) # this needs finishing
+        #[UH, tL] = ode45(@dget_tL, [UH0; UHp], [0; L0], [], f, g, v, kap, kJ, Lm, LT); 
+        Lp = tL[end][2]  # cm, struc length at puberty after time 0
+    end
+
+    UE0, Lb, info = initial_scaled_reserve(f, p_UE0, Lb)
+    SC = f * L .^ 3 .* (g ./ L + (1 + LT ./ L) / Lm) / (f + g)
+    SR = (1 - kap) * SC - kJ * UHp
+    R = (L >= Lp) * kapR .* SR / UE0 # set reprod rate of juveniles to zero
+    (R, UE0, Lb, Lp, info)
 end
 
 function reprod_rate(L, f, p)
     # created 2003/03/18 by Bas Kooijman, modified 2014/02/26
     # modified 2018/09/10 (fixed typos in description) Nina Marn
-    
+
     ## Syntax
     # [R, UE0, Lb, Lp, info] = <reprod_rate.m *reprod_rate*>(L, f, p)
-    
+
     ## Description
     # Calculates the reproduction rate in number of eggs per time
     # for an individual of length L and scaled reserve density f
@@ -133,16 +151,16 @@ function reprod_rate(L, f, p)
     # * Lb: scalar with (volumetric) length at birth
     # * Lp: scalar with (volumetric) length at puberty
     # * info: indicator with 1 for success, 0 otherwise
-    
+
     ## Remarks
     # See also <reprod_rate_foetus.html *reprod_rate_foetus*>, 
     #   <reprod_rate_j.html *reprod_rate_j*>, <reprod_rate_s.html *reprod_rate_s*>.
     # For cumulative reproduction, see <cum_reprod.html *cum_reprod*>,
-     #  <cum_reprod_j.html *cum_reprod_j*>, <cum_reprod_s.html *cum_reprod_s*>
-    
+    #  <cum_reprod_j.html *cum_reprod_j*>, <cum_reprod_s.html *cum_reprod_s*>
+
     ## Example of use
     # See <mydata_reprod_rate.m *mydata_reprod_rate*>
-    
+
     #  Explanation of variables:
     #  R = kapR * pR/ E0
     #  pR = (1 - kap) pC - kJ * EHp
@@ -157,33 +175,47 @@ function reprod_rate(L, f, p)
     #  SC = f (g/ L + (1 + LT/L)/ Lm)/ (f + g); Lm = v/ (kM g)
     #
     # unpack parameters; parameter sequence, cf get_pars_r
-  
-    kap = p[1]; kapR = p[2]; g = p[3]; kJ = p[4]; kM = p[5];
-    LT = p[6]; v = p[7]; UHb = p[8]; UHp = p[9];
-  
-    Lm = v/ (kM * g); # maximum length
-    k = kJ/ kM;       # -, maintenance ratio
-    VHb = UHb/ (1 - kap); VHp = UHp/ (1 - kap);
-    vHb = VHb * g^2 * kM^3/ v^2; vHp = VHp * g^2 * kM^3/ v^2; 
-  
-    p_lb = [g k vHb];             # pars for get_lb
-    p_lp = [g k LT/ Lm vHb vHp]; # pars for get_tp
-    p_UE0 = [VHb g kJ kM v];     # pars for initial_scaled_reserve  
-    p_mat = [kap kapR g kJ kM LT v UHb UHp]; # pars for maturity
-  
+
+    kap = p[1]
+    kapR = p[2]
+    g = p[3]
+    kJ = p[4]
+    kM = p[5]
+    LT = p[6]
+    v = p[7]
+    UHb = p[8]
+    UHp = p[9]
+
+    Lm = v / (kM * g) # maximum length
+    k = kJ / kM       # -, maintenance ratio
+    VHb = UHb / (1 - kap)
+    VHp = UHp / (1 - kap)
+    vHb = VHb * g^2 * kM^3 / v^2
+    vHp = VHp * g^2 * kM^3 / v^2
+
+    p_lb = [g k vHb]             # pars for get_lb
+    p_lp = [g k LT / Lm vHb vHp] # pars for get_tp
+    p_UE0 = [VHb g kJ kM v]     # pars for initial_scaled_reserve  
+    p_mat = [kap kapR g kJ kM LT v UHb UHp] # pars for maturity
+
     # if !@isdefined Lf
     #   Lf = [;];
     # end
-  
+
     # if length(Lf) <= 1
-      #lb0 = Lf/ Lm; # scaled length at birth
-      lp, lb, info_lp = get_lp(p_lp, f);
-      Lb = lb * Lm; Lp = lp * Lm; # structural length at birth, puberty
-      if info_lp != 1 # return at failure for tp
+    #lb0 = Lf/ Lm; # scaled length at birth
+    lp, lb, info_lp = get_lp(p_lp, f)
+    Lb = lb * Lm
+    Lp = lp * Lm # structural length at birth, puberty
+    if info_lp != 1 # return at failure for tp
         #fprintf('lp could not be obtained in reprod_rate \n')
-        R = L * 0; UE0 = [;];  Lb = [;]; Lp = [;]; info = info_lp;
-        return;
-      end
+        R = L * 0
+        UE0 = [;]
+        Lb = [;]
+        Lp = [;]
+        info = info_lp
+        return
+    end
     # else # if length Lb0 = 2
     #   L0 = Lf(1); # cm, structural length at time 0
     #   f0 = Lf(2); # -, scaled func response before time 0
@@ -198,21 +230,21 @@ function reprod_rate(L, f, p)
     #   [UH, tL] = ode45(@dget_tL, [UH0; UHp], [0; L0], [], f, g, v, kap, kJ, Lm, LT); 
     #   Lp = tL[end][2];  # cm, struc length at puberty after time 0
     # end
-  
-    UE0, Lb, info = initial_scaled_reserve(f, p_UE0);
-    SC = f * L.^3 .* (g ./ L + (1 + LT ./ L)/ Lm)/ (f + g);
-    SR = (1 - kap) * SC - kJ * UHp;
-    R = [L >= Lp] * kapR .* SR/ UE0; # set reprod rate of juveniles to zero
-    (R, UE0, Lb, Lp, info) 
+
+    UE0, Lb, info = initial_scaled_reserve(f, p_UE0)
+    SC = f * L .^ 3 .* (g ./ L + (1 + LT ./ L) / Lm) / (f + g)
+    SR = (1 - kap) * SC - kJ * UHp
+    R = [L >= Lp] * kapR .* SR / UE0 # set reprod rate of juveniles to zero
+    (R, UE0, Lb, Lp, info)
 end
 
 # Subfunctions
 
 function dget_tL(UH, tL, f, g, v, kap, kJ, Lm, LT)
-  # called by cum_reprod
-  L = tL[2];
-  r = v * (f/ L - (1 + LT/ L)/ Lm)/ (f + g); # 1/d, spec growth rate
-  dL = L * r/ 3; # cm/d, d/dt L
-  dUH = (1 - kap) * L^3 * f * (1/ L - r/ v) - kJ * UH; # cm^2, d/dt UH
-  dtL = [1; dL]/ dUH; # 1/cm, d/dUH L
+    # called by cum_reprod
+    L = tL[2]
+    r = v * (f / L - (1 + LT / L) / Lm) / (f + g) # 1/d, spec growth rate
+    dL = L * r / 3 # cm/d, d/dt L
+    dUH = (1 - kap) * L^3 * f * (1 / L - r / v) - kJ * UH # cm^2, d/dt UH
+    dtL = [1; dL] / dUH # 1/cm, d/dUH L
 end

--- a/src/lib/MultiCalib4DEB/configuration/calibration_options.jl
+++ b/src/lib/MultiCalib4DEB/configuration/calibration_options.jl
@@ -121,397 +121,439 @@ function calibration_options(key::String, val::String)
     if !@isdefined(key)
         key = "inexistent"
     end
-        if key in ["default", "search_method", "num_results", "gen_factor", "factor_type", "bounds_from_ind", 
-          "add_initial", "refine_best", "max_fun_evals", "max_calibration_time", "num_runs", "verbose", "verbose_options",
-          "seed_index", "random_seeds", "ranges", "results_printlnlay", "results_filename", "save_results", "mat_file", "sigma_share"]
-    #switch key 
-    #if key =={"default", ""}
-    if key == "default" || key == ""
-        search_method = "mm_shade" # Use mm_shade for parameter estimation
-        num_results = 50 # The size for the multimodal algorithm's population.
-        # If not defined then sets the values recommended by
-        # the author, which are 100 for mm_shade ("mm_shade") and
-        # 18 * problem size for L-mm_shade.
-        gen_factor = 0.5 # Percentage bounds for individual 
-        # initialization. (e.g. A value of 0.9 means
-        # that, for a parameter value of 1, the range
-        # for generation is [(1 - 0.9) * 1, 1 * (1 + 0.9)] so
-        # the new parameter value will be a random
-        # between [0.1, 1.9]
-        factor_type = "mult" # The kind of factor to be applied when generatin individuals 
-        #("mult" is multiplicative (Default) | "add" if
-        # additive);
-        bounds_from_ind = 1 # This options selects from where the 
-        # parameters for the initial population of
-        # individuals are taken. If the value is
-        # equal to 1 the parameters are generated
-        # from the data initial values if is 0 then
-        # the parameters are generated from the
-        # pseudo data values. 
-        add_initial = 0 # If to add an invidivual taken from initial 
-        # data into first population.
-        refine_initial = 0 # If a refinement is applied to the initial 
-        # individual of the population (only if it the
-        # "add_initial" option is activated)
-        refine_best = 0 # If a local search is applied to the best 
-        # individual found. 
-        #max_fun_evals = 20000; # The maximum number of function 
-        # evaluations to perform before to end the
-        # calibration process. 
-        max_calibration_time = 30 # The maximum calibration time
-        num_runs = 10 # The number of runs to perform. 
-        verbose = 0 # If to print some information while the calibration 
-        # process is running. 
-        verbose_options = 5 # The number of solutions to show from the 
-        # set of optimal solutions found by the
-        # algorithm through the calibration process.
-        random_seeds = [2147483647, 2874923758, 1284092845,
-            2783758913, 3287594328, 2328947617,
-            1217489374, 1815931031, 3278479237,
-            3342427357, 223758927, 3891375891,
-            1781589371, 1134872397, 2784732823,
-            2183647447, 24923758, 122845,
-            2783784093, 394328, 2328757617,
-            12174974, 18593131, 3287237,
-            33442757, 2235827, 3837891,
-            17159371, 34211397, 2842823] # The values of the
-        # seed used to
-        # generate random
-        # values (each one
-        # is used in a
-        # single run of the
-        # algorithm). 
-        seed_index = 1 # index for seeds for random number generator
-        #rng(random_seeds(seed_index), "twister"); # initialize the number generator is with a seed, to be updated for each run of the calibration method. 
-        MersenneTwister(random_seeds[seed_index]) # initialize the number generator is with a seed, to be updated for each run of the calibration method.
-        ranges = nothing #struct(); # The range struct is empty by default. 
-        results_printlnlay = "Basic" # The results output style.
-        results_filename = "Default"
-        save_results = false # If results output are saved.
-        mat_file = "" # .mat filename for simulation results.
-        sigma_share = 0.1 # Minimum distance between individuals to sanction them in Fitness Sharing. 
-    end
-
-    if key == "search_method"
-        if !@isdefined(val)
-            search_method = "mm_shade" # Select mm_shade as the default method.
-        else
-            search_method = val
-        end
-    end
-    if key == "num_results"
-        if !@isdefined(val)
-            if length(num_results) != 0
-                println("num_results = " * string(num_results) * " \n")
-            else
-                println("num_results = unknown \n")
-            end
-        else
-            if num_results < 1
-                num_results = 10
-            else
-                num_results = val
-            end
-        end
-    end
-    if key == "gen_factor"
-        if !@isdefined(val)
-            if length(gen_factor) != 0.0
-                println("gen_factor = ", string(gen_factor), " \n")
-            else
-                println("gen_factor = unknown \n")
-            end
-        else
-            gen_factor = val
-        end
-    end
-    if key == "factor_type"
-        println("e")
-        if !@isdefined(val)
-            println("a")
-            if length(factor_type) != 0.0
-                println("o")
-                println("factor_type = ", factor_type, " \n")
-            else
-                println("factor_type = unknown \n")
-            end
-            factor_type = val
-        end
-    end
-    if key == "bounds_from_ind"
-        if !@isdefined(val)
-            if length(bounds_from_ind) != 0
-                println("bounds_from_ind = ", string(bounds_from_ind), " \n")
-            else
-                println("bounds_from_ind = unknown \n")
-            end
-        else
-            bounds_from_ind = val
-        end
-    end
-    if key == "add_initial"
-        if !@isdefined(val)
-            if length(add_initial) != 0
-                println("add_initial = ", string(add_initial), " \n")
-            else
-                println("add_initial = unknown \n")
-            end
-        else
-            add_initial = val
-        end
-    end
-    if key == "refine_best"
-        if !@isdefined(val)
-            if length(refine_best) != 0
-                println("refine_best = ", string(refine_best), " \n")
-            else
-                println("refine_best = unknown \n")
-            end
-        else
-            refine_best = val
-        end
-    end
-    if key == "max_fun_evals"
-        if !@isdefined(val)
-            if length(max_fun_evals) != 0
-                println("max_fun_evals = ", string(max_fun_evals), " \n")
-            else
-                println("max_fun_evals = unknown \n")
-            end
-        else
-            max_fun_evals = val
-            max_calibration_time = Inf
-        end
-    end
-    if key == "max_calibration_time"
-        if !@isdefined(val)
-            if length(max_calibration_time) != 0
-                println("max_calibration_time = ", string(max_calibration_time), " \n")
-            else
-                println("max_calibration_time = unknown \n")
-            end
-        else
-            max_calibration_time = val
-            max_fun_evals = Inf
-        end
-    end
-    if key == "num_runs"
-        if !@isdefined(val)
-            if length(max_fun_evals) != 0
-                println("num_runs = ", string(num_runs), " \n")
-            else
-                println("num_runs = unknown \n")
-            end
-        else
-            num_runs = val
-        end
-    end
-    if key == "verbose"
-        if !@isdefined(val)
-            if length(verbose) != 0
-                println("verbose = ", string(verbose), " \n")
-            else
-                println("verbose = unknown \n")
-            end
-        else
-            verbose = val
-        end
-    end
-    if key == "verbose_options"
-        if !@isdefined(val)
-            if length(verbose_options) != 0
-                println("verbose_options = ", string(verbose_options), " \n")
-            else
-                println("verbose_options = unknown \n")
-            end
-        else
-            verbose_options = val
-        end
-    end
-    if key == "seed_index"
-        if !@isdefined(val)
-            if length(random_seeds) != 0
-                println("seed_index = ", string(seed_index(1)), " \n")
-            else
-                println("seed_index = unknown \n")
-            end
-        else
-            seed_index = val
-        end
-        rng(random_seeds(seed_index), "twister") # initialize the random number generator
-    end
-    if key == "random_seeds"
-        if !@isdefined(val)
-            if length(random_seeds) != 0
-                println("random_seeds = ", string(random_seeds), " \n")
-            else
-                println("random_seeds = unknown \n")
-            end
-        else
-            random_seeds = val
-        end
-    end
-    if key == "ranges"
-        if !@isdefined(val)
-            if length(ranges) != 0
-                println("ranges = ", string(ranges), " \n")
-            else
-                println("ranges = unknown \n")
-            end
-        else
-            ranges = val
-        end
-    end
-    if key == "results_printlnlay"
-        if !@isdefined(val)
-            if results_printlnlay == "Basic"
-                println("results_printlnlay = ", results_printlnlay, " \n")
-            elseif results_printlnlay == "Best"
-                println("results_printlnlay = ", results_printlnlay, " \n")
-            elseif results_printlnlay == "Set"
-                println("results_printlnlay = ", results_printlnlay, " \n")
-            elseif results_printlnlay == "Complete"
-                println("results_printlnlay = ", results_printlnlay, " \n")
-            else
-                println("results_printlnlay = unknown \n")
-            end
-        else
-            results_printlnlay = val
-        end
-    end
-    if key == "results_filename"
-        if !@isdefined(val)
+    if key in [
+        "default",
+        "search_method",
+        "num_results",
+        "gen_factor",
+        "factor_type",
+        "bounds_from_ind",
+        "add_initial",
+        "refine_best",
+        "max_fun_evals",
+        "max_calibration_time",
+        "num_runs",
+        "verbose",
+        "verbose_options",
+        "seed_index",
+        "random_seeds",
+        "ranges",
+        "results_printlnlay",
+        "results_filename",
+        "save_results",
+        "mat_file",
+        "sigma_share",
+    ]
+        #switch key 
+        #if key =={"default", ""}
+        if key == "default" || key == ""
+            search_method = "mm_shade" # Use mm_shade for parameter estimation
+            num_results = 50 # The size for the multimodal algorithm's population.
+            # If not defined then sets the values recommended by
+            # the author, which are 100 for mm_shade ("mm_shade") and
+            # 18 * problem size for L-mm_shade.
+            gen_factor = 0.5 # Percentage bounds for individual 
+            # initialization. (e.g. A value of 0.9 means
+            # that, for a parameter value of 1, the range
+            # for generation is [(1 - 0.9) * 1, 1 * (1 + 0.9)] so
+            # the new parameter value will be a random
+            # between [0.1, 1.9]
+            factor_type = "mult" # The kind of factor to be applied when generatin individuals 
+            #("mult" is multiplicative (Default) | "add" if
+            # additive);
+            bounds_from_ind = 1 # This options selects from where the 
+            # parameters for the initial population of
+            # individuals are taken. If the value is
+            # equal to 1 the parameters are generated
+            # from the data initial values if is 0 then
+            # the parameters are generated from the
+            # pseudo data values. 
+            add_initial = 0 # If to add an invidivual taken from initial 
+            # data into first population.
+            refine_initial = 0 # If a refinement is applied to the initial 
+            # individual of the population (only if it the
+            # "add_initial" option is activated)
+            refine_best = 0 # If a local search is applied to the best 
+            # individual found. 
+            #max_fun_evals = 20000; # The maximum number of function 
+            # evaluations to perform before to end the
+            # calibration process. 
+            max_calibration_time = 30 # The maximum calibration time
+            num_runs = 10 # The number of runs to perform. 
+            verbose = 0 # If to print some information while the calibration 
+            # process is running. 
+            verbose_options = 5 # The number of solutions to show from the 
+            # set of optimal solutions found by the
+            # algorithm through the calibration process.
+            random_seeds = [
+                2147483647,
+                2874923758,
+                1284092845,
+                2783758913,
+                3287594328,
+                2328947617,
+                1217489374,
+                1815931031,
+                3278479237,
+                3342427357,
+                223758927,
+                3891375891,
+                1781589371,
+                1134872397,
+                2784732823,
+                2183647447,
+                24923758,
+                122845,
+                2783784093,
+                394328,
+                2328757617,
+                12174974,
+                18593131,
+                3287237,
+                33442757,
+                2235827,
+                3837891,
+                17159371,
+                34211397,
+                2842823,
+            ] # The values of the
+            # seed used to
+            # generate random
+            # values (each one
+            # is used in a
+            # single run of the
+            # algorithm). 
+            seed_index = 1 # index for seeds for random number generator
+            #rng(random_seeds(seed_index), "twister"); # initialize the number generator is with a seed, to be updated for each run of the calibration method. 
+            MersenneTwister(random_seeds[seed_index]) # initialize the number generator is with a seed, to be updated for each run of the calibration method.
+            ranges = nothing #struct(); # The range struct is empty by default. 
+            results_printlnlay = "Basic" # The results output style.
             results_filename = "Default"
-        else
-            results_filename = val
+            save_results = false # If results output are saved.
+            mat_file = "" # .mat filename for simulation results.
+            sigma_share = 0.1 # Minimum distance between individuals to sanction them in Fitness Sharing. 
         end
-    end
-    if key == "save_results"
-        if !@isdefined(val)
-            if length(save_results) != 0
-                println("save_results = ", save_results, " \n")
+
+        if key == "search_method"
+            if !@isdefined(val)
+                search_method = "mm_shade" # Select mm_shade as the default method.
             else
-                println("save_results = unknown \n")
+                search_method = val
             end
-        else
-            save_results = val
         end
-    end
-    if key == "mat_file"
-        if !@isdefined(val)
-            mat_file = ""
-        else
-            mat_file = val
-        end
-    end
-    if key == "sigma_share"
-        if !@isdefined(val)
-            if length(sigma_share) != 0.0
-                println("sigma_share = ", string(sigma_share), " \n")
-            else
-                println("sigma_share = unknown \n")
-            end
-        else
-            if val > 1.0
-                val = 1.0
-            elseif val < 0.0
-                val = 0.0
-            end
-            sigma_share = val
-        end
-    end
-        else
-             if key != "inexistent" 
-                println("key ", key, " is unknown \n\n");
-             end
-             if search_method != ""
-                println("search_method = ", search_method," \n");
-             else
-                println("search_method = unknown \n");
-             end
-             if length(num_results) != 0.0
-                println("num_results = ", string(num_results)," \n");
-             else
-                println("num_results = unknown \n");
-             end
-             if length(gen_factor) != 0.0
-                println("gen_factor = ", string(gen_factor)," \n");
-             else
-                println("gen_factor = unknown \n");
-             end	
-             if length(factor_type) != 0
-                println("factor_type = ", factor_type," \n");
-              else
-                println("factor_type = unknown \n");
-              end
-             if length(bounds_from_ind) != 0.0
-                println("bounds_from_ind = ", string(bounds_from_ind)," \n");
-             else
-                println("bounds_from_ind = unknown \n");
-             end
-             if length(max_fun_evals) != 0
-                println("max_fun_evals = ", string(max_fun_evals)," \n");
-             else
-                println("max_fun_evals = unknown \n");
-             end
-             if length(max_calibration_time) != 0
-                println("max_calibration_time = ", string(max_calibration_time)," \n");
-             else
-                println("max_calibration_time = unknown \n");
-             end
-             if length(num_runs) != 0
-                println("num_runs = ", string(num_runs)," \n");
-             else
-                println("num_runs = unknown \n");
-             end
-             if length(add_initial) != 0
-                println("add_initial = ", string(add_initial)," \n");
-             else
-                println("add_initial = unknown \n");
-             end
-             if length(refine_best) != 0
-                println("refine_best = ", string(refine_best)," \n");
-             else
-                println("refine_best = unknown \n");
-             end
-             if length(verbose) != 0
-                println("verbose = ", string(verbose)," \n");
-             else
-                println("verbose = unknown \n");
-             end
-             if length(verbose_options) != 0
-                println("verbose_options = ", string(verbose_options)," \n");
-             else
-                println("verbose_options = unknown \n");
-             end
-             if exist("ranges","var")
-                if isempty(ranges)
-                   println("No ranges defined \n");
+        if key == "num_results"
+            if !@isdefined(val)
+                if length(num_results) != 0
+                    println("num_results = " * string(num_results) * " \n")
                 else
-                   println(size(ranges), "ranges defined \n");
+                    println("num_results = unknown \n")
                 end
-             else
-                println("ranges = unknown \n");
-             end
-             if results_printlnlay != ""
-                println("results_printlnlay = ", results_printlnlay," \n");
-             else
-                println("results_printlnlay = unknown \n");
-             end
-             if results_filename != ""
-                println("results_filename = ", results_filename," \n");
-             else
-                println("results_filename = unknown \n");
-             end
-             if mat_file != ""
-                println("mat_file = ", mat_file," \n");
-             else
-                println("mat_file = unknown \n");
-             end
-             if sigma_share != ""
-                println("sigma_share = ", sigma_share," \n");
-             else
-                println("sigma_share = unknown \n");
-             end
+            else
+                if num_results < 1
+                    num_results = 10
+                else
+                    num_results = val
+                end
             end
+        end
+        if key == "gen_factor"
+            if !@isdefined(val)
+                if length(gen_factor) != 0.0
+                    println("gen_factor = ", string(gen_factor), " \n")
+                else
+                    println("gen_factor = unknown \n")
+                end
+            else
+                gen_factor = val
+            end
+        end
+        if key == "factor_type"
+            println("e")
+            if !@isdefined(val)
+                println("a")
+                if length(factor_type) != 0.0
+                    println("o")
+                    println("factor_type = ", factor_type, " \n")
+                else
+                    println("factor_type = unknown \n")
+                end
+                factor_type = val
+            end
+        end
+        if key == "bounds_from_ind"
+            if !@isdefined(val)
+                if length(bounds_from_ind) != 0
+                    println("bounds_from_ind = ", string(bounds_from_ind), " \n")
+                else
+                    println("bounds_from_ind = unknown \n")
+                end
+            else
+                bounds_from_ind = val
+            end
+        end
+        if key == "add_initial"
+            if !@isdefined(val)
+                if length(add_initial) != 0
+                    println("add_initial = ", string(add_initial), " \n")
+                else
+                    println("add_initial = unknown \n")
+                end
+            else
+                add_initial = val
+            end
+        end
+        if key == "refine_best"
+            if !@isdefined(val)
+                if length(refine_best) != 0
+                    println("refine_best = ", string(refine_best), " \n")
+                else
+                    println("refine_best = unknown \n")
+                end
+            else
+                refine_best = val
+            end
+        end
+        if key == "max_fun_evals"
+            if !@isdefined(val)
+                if length(max_fun_evals) != 0
+                    println("max_fun_evals = ", string(max_fun_evals), " \n")
+                else
+                    println("max_fun_evals = unknown \n")
+                end
+            else
+                max_fun_evals = val
+                max_calibration_time = Inf
+            end
+        end
+        if key == "max_calibration_time"
+            if !@isdefined(val)
+                if length(max_calibration_time) != 0
+                    println("max_calibration_time = ", string(max_calibration_time), " \n")
+                else
+                    println("max_calibration_time = unknown \n")
+                end
+            else
+                max_calibration_time = val
+                max_fun_evals = Inf
+            end
+        end
+        if key == "num_runs"
+            if !@isdefined(val)
+                if length(max_fun_evals) != 0
+                    println("num_runs = ", string(num_runs), " \n")
+                else
+                    println("num_runs = unknown \n")
+                end
+            else
+                num_runs = val
+            end
+        end
+        if key == "verbose"
+            if !@isdefined(val)
+                if length(verbose) != 0
+                    println("verbose = ", string(verbose), " \n")
+                else
+                    println("verbose = unknown \n")
+                end
+            else
+                verbose = val
+            end
+        end
+        if key == "verbose_options"
+            if !@isdefined(val)
+                if length(verbose_options) != 0
+                    println("verbose_options = ", string(verbose_options), " \n")
+                else
+                    println("verbose_options = unknown \n")
+                end
+            else
+                verbose_options = val
+            end
+        end
+        if key == "seed_index"
+            if !@isdefined(val)
+                if length(random_seeds) != 0
+                    println("seed_index = ", string(seed_index(1)), " \n")
+                else
+                    println("seed_index = unknown \n")
+                end
+            else
+                seed_index = val
+            end
+            rng(random_seeds(seed_index), "twister") # initialize the random number generator
+        end
+        if key == "random_seeds"
+            if !@isdefined(val)
+                if length(random_seeds) != 0
+                    println("random_seeds = ", string(random_seeds), " \n")
+                else
+                    println("random_seeds = unknown \n")
+                end
+            else
+                random_seeds = val
+            end
+        end
+        if key == "ranges"
+            if !@isdefined(val)
+                if length(ranges) != 0
+                    println("ranges = ", string(ranges), " \n")
+                else
+                    println("ranges = unknown \n")
+                end
+            else
+                ranges = val
+            end
+        end
+        if key == "results_printlnlay"
+            if !@isdefined(val)
+                if results_printlnlay == "Basic"
+                    println("results_printlnlay = ", results_printlnlay, " \n")
+                elseif results_printlnlay == "Best"
+                    println("results_printlnlay = ", results_printlnlay, " \n")
+                elseif results_printlnlay == "Set"
+                    println("results_printlnlay = ", results_printlnlay, " \n")
+                elseif results_printlnlay == "Complete"
+                    println("results_printlnlay = ", results_printlnlay, " \n")
+                else
+                    println("results_printlnlay = unknown \n")
+                end
+            else
+                results_printlnlay = val
+            end
+        end
+        if key == "results_filename"
+            if !@isdefined(val)
+                results_filename = "Default"
+            else
+                results_filename = val
+            end
+        end
+        if key == "save_results"
+            if !@isdefined(val)
+                if length(save_results) != 0
+                    println("save_results = ", save_results, " \n")
+                else
+                    println("save_results = unknown \n")
+                end
+            else
+                save_results = val
+            end
+        end
+        if key == "mat_file"
+            if !@isdefined(val)
+                mat_file = ""
+            else
+                mat_file = val
+            end
+        end
+        if key == "sigma_share"
+            if !@isdefined(val)
+                if length(sigma_share) != 0.0
+                    println("sigma_share = ", string(sigma_share), " \n")
+                else
+                    println("sigma_share = unknown \n")
+                end
+            else
+                if val > 1.0
+                    val = 1.0
+                elseif val < 0.0
+                    val = 0.0
+                end
+                sigma_share = val
+            end
+        end
+    else
+        if key != "inexistent"
+            println("key ", key, " is unknown \n\n")
+        end
+        if search_method != ""
+            println("search_method = ", search_method, " \n")
+        else
+            println("search_method = unknown \n")
+        end
+        if length(num_results) != 0.0
+            println("num_results = ", string(num_results), " \n")
+        else
+            println("num_results = unknown \n")
+        end
+        if length(gen_factor) != 0.0
+            println("gen_factor = ", string(gen_factor), " \n")
+        else
+            println("gen_factor = unknown \n")
+        end
+        if length(factor_type) != 0
+            println("factor_type = ", factor_type, " \n")
+        else
+            println("factor_type = unknown \n")
+        end
+        if length(bounds_from_ind) != 0.0
+            println("bounds_from_ind = ", string(bounds_from_ind), " \n")
+        else
+            println("bounds_from_ind = unknown \n")
+        end
+        if length(max_fun_evals) != 0
+            println("max_fun_evals = ", string(max_fun_evals), " \n")
+        else
+            println("max_fun_evals = unknown \n")
+        end
+        if length(max_calibration_time) != 0
+            println("max_calibration_time = ", string(max_calibration_time), " \n")
+        else
+            println("max_calibration_time = unknown \n")
+        end
+        if length(num_runs) != 0
+            println("num_runs = ", string(num_runs), " \n")
+        else
+            println("num_runs = unknown \n")
+        end
+        if length(add_initial) != 0
+            println("add_initial = ", string(add_initial), " \n")
+        else
+            println("add_initial = unknown \n")
+        end
+        if length(refine_best) != 0
+            println("refine_best = ", string(refine_best), " \n")
+        else
+            println("refine_best = unknown \n")
+        end
+        if length(verbose) != 0
+            println("verbose = ", string(verbose), " \n")
+        else
+            println("verbose = unknown \n")
+        end
+        if length(verbose_options) != 0
+            println("verbose_options = ", string(verbose_options), " \n")
+        else
+            println("verbose_options = unknown \n")
+        end
+        if exist("ranges", "var")
+            if isempty(ranges)
+                println("No ranges defined \n")
+            else
+                println(size(ranges), "ranges defined \n")
+            end
+        else
+            println("ranges = unknown \n")
+        end
+        if results_printlnlay != ""
+            println("results_printlnlay = ", results_printlnlay, " \n")
+        else
+            println("results_printlnlay = unknown \n")
+        end
+        if results_filename != ""
+            println("results_filename = ", results_filename, " \n")
+        else
+            println("results_filename = unknown \n")
+        end
+        if mat_file != ""
+            println("mat_file = ", mat_file, " \n")
+        else
+            println("mat_file = unknown \n")
+        end
+        if sigma_share != ""
+            println("sigma_share = ", sigma_share, " \n")
+        else
+            println("sigma_share = unknown \n")
+        end
+    end
 end

--- a/src/lib/misc/beta0.jl
+++ b/src/lib/misc/beta0.jl
@@ -3,52 +3,62 @@
 
 ##
 function beta0(x0, x1)
-  # created 2000/08/16 by Bas Kooijman; modified 2011/04/10, 2017/07/24
-  
-  ## Syntax
-  # f = <../beta0.m *beta0*> (x0,x1)
-  
-  ## Description
-  #  particular incomplete beta function:
-  #   B_x1(4/3,0) - B_x0(4/3,0) = \int_x0^x1 t^(4/3-1) (1-t)^(-1) dt
-  #
-  # Input
-  #
-  # * x0: scalar with lower boundary for integration
-  # * x1: scalar with upper boundary for integration
-  #
-  # Output
-  #
-  # * f: scalar with particular incomple beta function
-  
-  ## Remarks
-  # See also <../lib/misc/beta_34_0 *beta_34_0*>
-  
-  ## Example of use
-  # beta0(0.1, 0.2)
-  
-  # if x0 < 0 | x0 >= 1 | x1 < 0 | x1 >= 1
-  #   println("Warning from beta0: argument values (" * string(x0) * "," * string(x1) * ") outside (0,1) \n");
-  #   f = [;];
-  #   dbstack
-  #   return;
-  # elseif x0 > x1
-  #   println("Warning from beta0: lower boundary " * string(x0) * " larger than upper boundary " * string(x1) * " \n");
-  #   f = [;];
-  #   dbstack
-  #   return;
-  # end
+    # created 2000/08/16 by Bas Kooijman; modified 2011/04/10, 2017/07/24
 
-  n0 = length(x0); n1 = length(x1);
-  if n0 != n1 && n0 != 1 && n1 != 1
-    println("Warning from beta0: argument values (" * num2str(x0) * "," * num2str(x1), ") outside (0,1) \n");
-    f = [;];
-    dbstack
-    return;
-  end
+    ## Syntax
+    # f = <../beta0.m *beta0*> (x0,x1)
 
-  x03 = x0 .^ (1/ 3); x13 = x1 .^ (1/ 3); a3 = sqrt(3);
-  f1 = - 3 * x13 + a3 * atan((1 + 2 * x13)/ a3) - log(Complex(x13 - 1)) +  log(1 + x13 + x13 .^ 2)/ 2;
-  f0 = - 3 * x03 .+ a3 * atan.((1 .+ 2 * x03)/ a3) - log.(Complex.(x03 .- 1)) + log.(Complex.(1 .+ x03 .+ x03 .^ 2))/ 2;
-  f = f1 .- f0;
+    ## Description
+    #  particular incomplete beta function:
+    #   B_x1(4/3,0) - B_x0(4/3,0) = \int_x0^x1 t^(4/3-1) (1-t)^(-1) dt
+    #
+    # Input
+    #
+    # * x0: scalar with lower boundary for integration
+    # * x1: scalar with upper boundary for integration
+    #
+    # Output
+    #
+    # * f: scalar with particular incomple beta function
+
+    ## Remarks
+    # See also <../lib/misc/beta_34_0 *beta_34_0*>
+
+    ## Example of use
+    # beta0(0.1, 0.2)
+
+    # if x0 < 0 | x0 >= 1 | x1 < 0 | x1 >= 1
+    #   println("Warning from beta0: argument values (" * string(x0) * "," * string(x1) * ") outside (0,1) \n");
+    #   f = [;];
+    #   dbstack
+    #   return;
+    # elseif x0 > x1
+    #   println("Warning from beta0: lower boundary " * string(x0) * " larger than upper boundary " * string(x1) * " \n");
+    #   f = [;];
+    #   dbstack
+    #   return;
+    # end
+
+    n0 = length(x0)
+    n1 = length(x1)
+    if n0 != n1 && n0 != 1 && n1 != 1
+        println(
+            "Warning from beta0: argument values (" * num2str(x0) * "," * num2str(x1),
+            ") outside (0,1) \n",
+        )
+        f = [;]
+        dbstack
+        return
+    end
+
+    x03 = x0 .^ (1 / 3)
+    x13 = x1 .^ (1 / 3)
+    a3 = sqrt(3)
+    f1 =
+        -3 * x13 + a3 * atan((1 + 2 * x13) / a3) - log(Complex(x13 - 1)) +
+        log(1 + x13 + x13 .^ 2) / 2
+    f0 =
+        -3 * x03 .+ a3 * atan.((1 .+ 2 * x03) / a3) - log.(Complex.(x03 .- 1)) +
+        log.(Complex.(1 .+ x03 .+ x03 .^ 2)) / 2
+    f = f1 .- f0
 end

--- a/src/lib/misc/tempcorr.jl
+++ b/src/lib/misc/tempcorr.jl
@@ -3,85 +3,91 @@
 
 ##
 function tempcorr(T, T_ref, pars_T)
-  #  Created at 2002/04/09 by Bas Kooijman; modified 2005/01/24, 2016/11/18, 
-  #  Dina Lika & Bas Kooijman: 2019/02/26
-  
-  ## Syntax
-  # TC = <../tempcorr.m *tempcorr*> (T, T_ref, pars_T)
+    #  Created at 2002/04/09 by Bas Kooijman; modified 2005/01/24, 2016/11/18, 
+    #  Dina Lika & Bas Kooijman: 2019/02/26
 
-  ## Description
-  #  Calculates the factor with which physiological rates should be multiplied 
-  #    to go from a reference temperature to a given temperature.
-  #  The 3-parameter version models low or high temerature torpor, depending the the value of the boudary temparature, relative to the  reference temperatur, the 5-parameter version models both.
-  #  The 5- parameter version assumes that the reference temperature is between the lower and upper temperature boundaries.
-  #
-  # Input
-  #
-  # * T: vector with temperatures in K
-  # * T_ref: scalar with reference temperature in K
-  # * pars_T: 1-, 3- or 5-vector with temperature parameters in K
-  #
-  #    1: T_A: Arrhenius temperature
-  #    3: T_A, T_L, T_AL or T_A, T_H, T_AH: Arrhenius temperature, boundary temperature, Arrhenius temperature for that boundary temperature
-  #    5: T_A, T_L, T_H, T_AL, T_AH    
-  #
-  # Output:
-  #
-  # * TC: vector with temperature correction factor(s) that affect(s) all rates
-   
-  ## Remarks
-  #  The intended use is: (rate at  T) = (rate at T_ref) * tempcorr (T, T_ref, pars_T). 
-  #  Notice that tempcorr (T_ref, T_ref, pars_T) results in the value 1, independent of pars_T.
-  #  Notice also that the result with one parameter is always larger than with 3 or 5 parameters, with the same first parameter.
-  #  The Arrhenius temperature T_A affects rates at the full temperature-range. 
-  #
-  #  The interpretation of the parameters in the 3-parameter version depends on the value of pars_T(2), relative to T_ref.
-  #  If pars_T(2) < T_ref, it is assumed that T_L = pars_T(2) and T_AL = pars_T(3), and low-temperature torpor is modelled.
-  #  If pars_T(2) > T_ref, it is assumed that T_H = pars_T(2) and T_AH = pars_T(3), and high-temperature torpor is modelled.
-  #
-  #  Low-temperature torpor does not affect rates at temperatures larger than T_ref; the reverse applies for high-temperature torpor.
-  #  This also holds for the 5-parameter version. 
-  #
-  #  <shtempcorr.html *shtempcorr*> shows a graph of this correction factor as function of the temperature. 
+    ## Syntax
+    # TC = <../tempcorr.m *tempcorr*> (T, T_ref, pars_T)
 
-  ## Example of use
-  #  tempcorr([330 331 332], 320, [12000 277 328 20000 190000]) and 
-  #  shtemp2corr(320, [12000 277 328 20000 190000]). 
+    ## Description
+    #  Calculates the factor with which physiological rates should be multiplied 
+    #    to go from a reference temperature to a given temperature.
+    #  The 3-parameter version models low or high temerature torpor, depending the the value of the boudary temparature, relative to the  reference temperatur, the 5-parameter version models both.
+    #  The 5- parameter version assumes that the reference temperature is between the lower and upper temperature boundaries.
+    #
+    # Input
+    #
+    # * T: vector with temperatures in K
+    # * T_ref: scalar with reference temperature in K
+    # * pars_T: 1-, 3- or 5-vector with temperature parameters in K
+    #
+    #    1: T_A: Arrhenius temperature
+    #    3: T_A, T_L, T_AL or T_A, T_H, T_AH: Arrhenius temperature, boundary temperature, Arrhenius temperature for that boundary temperature
+    #    5: T_A, T_L, T_H, T_AL, T_AH    
+    #
+    # Output:
+    #
+    # * TC: vector with temperature correction factor(s) that affect(s) all rates
 
-  T_A = pars_T[1]; # Arrhenius temperature
-    s_A = exp(T_A/ T_ref - T_A ./ T);  # Arrhenius factor
-    
-  if length(pars_T) == 1
-    TC = s_A;
-    
-  elseif length(pars_T) == 3 # either low-temperature torpor or high-temperature torpor
-    if pars_T[2] < T_ref
-      T_L  = pars_T[2]; # Lower temp boundary
-      T_AL = pars_T[3]; # Arrh. temp for lower boundary
-      s_L_ratio = (1 + exp(T_AL ./ T_ref - T_AL/ T_L)) ./ (1 + exp(T_AL ./ T     - T_AL/ T_L));
-      TC = s_A .* ((T <= T_ref) .* s_L_ratio + (T > T_ref));
-    else # pars_T(2) > T_ref
-      T_H  = pars_T(2); # Upper temp boundary
-      T_AH = pars_T(3); # Arrh. temp for upper boundary
-      s_H_ratio = (1 + exp(T_AH/ T_H - T_AH ./ T_ref)) ./ (1 + exp(T_AH/ T_H - T_AH ./ T    ));
-      TC = s_A .* ((T >= T_ref) .* s_H_ratio + (T < T_ref));
+    ## Remarks
+    #  The intended use is: (rate at  T) = (rate at T_ref) * tempcorr (T, T_ref, pars_T). 
+    #  Notice that tempcorr (T_ref, T_ref, pars_T) results in the value 1, independent of pars_T.
+    #  Notice also that the result with one parameter is always larger than with 3 or 5 parameters, with the same first parameter.
+    #  The Arrhenius temperature T_A affects rates at the full temperature-range. 
+    #
+    #  The interpretation of the parameters in the 3-parameter version depends on the value of pars_T(2), relative to T_ref.
+    #  If pars_T(2) < T_ref, it is assumed that T_L = pars_T(2) and T_AL = pars_T(3), and low-temperature torpor is modelled.
+    #  If pars_T(2) > T_ref, it is assumed that T_H = pars_T(2) and T_AH = pars_T(3), and high-temperature torpor is modelled.
+    #
+    #  Low-temperature torpor does not affect rates at temperatures larger than T_ref; the reverse applies for high-temperature torpor.
+    #  This also holds for the 5-parameter version. 
+    #
+    #  <shtempcorr.html *shtempcorr*> shows a graph of this correction factor as function of the temperature. 
+
+    ## Example of use
+    #  tempcorr([330 331 332], 320, [12000 277 328 20000 190000]) and 
+    #  shtemp2corr(320, [12000 277 328 20000 190000]). 
+
+    T_A = pars_T[1] # Arrhenius temperature
+    s_A = exp(T_A / T_ref - T_A ./ T)  # Arrhenius factor
+
+    if length(pars_T) == 1
+        TC = s_A
+
+    elseif length(pars_T) == 3 # either low-temperature torpor or high-temperature torpor
+        if pars_T[2] < T_ref
+            T_L = pars_T[2] # Lower temp boundary
+            T_AL = pars_T[3] # Arrh. temp for lower boundary
+            s_L_ratio =
+                (1 + exp(T_AL ./ T_ref - T_AL / T_L)) ./ (1 + exp(T_AL ./ T - T_AL / T_L))
+            TC = s_A .* ((T <= T_ref) .* s_L_ratio + (T > T_ref))
+        else # pars_T(2) > T_ref
+            T_H = pars_T(2) # Upper temp boundary
+            T_AH = pars_T(3) # Arrh. temp for upper boundary
+            s_H_ratio =
+                (1 + exp(T_AH / T_H - T_AH ./ T_ref)) ./ (1 + exp(T_AH / T_H - T_AH ./ T))
+            TC = s_A .* ((T >= T_ref) .* s_H_ratio + (T < T_ref))
+        end
+
+    else # length(pars_T) == 5: both low- and high-temperature torpor
+        T_L = pars_T(2)  # Lower temp boundary
+        T_H = pars_T(3)  # Upper temp boundary
+        T_AL = pars_T(4)  # Arrh. temp for lower boundary
+        T_AH = pars_T(5)  # Arrh. temp for upper boundary
+
+        if T_L > T_ref || T_H < T_ref
+            println(
+                "Warning from temp_corr: invalid parameter combination, T_L > T_ref and/or T_H < T_ref\n",
+            )
+            TC = []
+            return
+        end
+
+        s_L_ratio =
+            (1 + exp(T_AL / T_ref - T_AL / T_L)) ./ (1 + exp(T_AL ./ T - T_AL / T_L))
+        s_H_ratio =
+            (1 + exp(T_AH / T_H - T_AH / T_ref)) ./ (1 + exp(T_AH / T_H - T_AH ./ T))
+        TC = s_A .* ((T <= T_ref) .* s_L_ratio + (T > T_ref) .* s_H_ratio)
     end
-         
-  else # length(pars_T) == 5: both low- and high-temperature torpor
-    T_L  = pars_T(2);  # Lower temp boundary
-    T_H  = pars_T(3);  # Upper temp boundary
-    T_AL = pars_T(4);  # Arrh. temp for lower boundary
-    T_AH = pars_T(5);  # Arrh. temp for upper boundary
-    
-    if T_L > T_ref || T_H < T_ref
-      println("Warning from temp_corr: invalid parameter combination, T_L > T_ref and/or T_H < T_ref\n")
-      TC = [];
-      return
-    end
-
-    s_L_ratio = (1 + exp(T_AL/ T_ref - T_AL/ T_L)) ./ (1 + exp(T_AL ./ T   - T_AL/ T_L));
-    s_H_ratio = (1 + exp(T_AH/ T_H - T_AH/ T_ref)) ./ (1 + exp(T_AH/ T_H - T_AH ./ T  ));
-    TC = s_A .* ((T <= T_ref) .* s_L_ratio + (T > T_ref) .* s_H_ratio);    
-  end
-  (TC)
+    (TC)
 end

--- a/src/lib/pet/addpseudodata.jl
+++ b/src/lib/pet/addpseudodata.jl
@@ -37,10 +37,10 @@ using Unitful
 using Unitful: °C, K, d, g, cm, mol, J =#
 # set pseudodata
 @with_kw mutable struct psdData_struct{L,R,M}
-    v::L = 0.02cm/d
+    v::L = 0.02cm / d
     kap::Float64 = 0.8
     kap_R::Float64 = 0.95
-    p_M::M = 18J/d/cm^3
+    p_M::M = 18J / d / cm^3
     k_J::R = 0.002d^-1
     kap_G::Float64 = 0.8
     k::Float64 = 0.3

--- a/src/lib/pet/estim_options.jl
+++ b/src/lib/pet/estim_options.jl
@@ -2,771 +2,803 @@
 # Sets options for estim.pars
 
 ##
-  #  created at 2015/01/25 by Goncalo Marques; 
-  #  modified 2015/03/26 by Goncalo Marques, 2018/05/21, 2018/08/21 by Bas Kooijman, 
-  #    2019/12/20 by Nina Marn, 2021/06/07 by Bas Kooijman & Juan Robles,
-  #    2021/10/20, 2022/04/24 by Juan Robles
-  
-  ## Syntax
-  # <../estim_options.m *estim_options*> (key, val)
-  
-  ## Description
-  # Sets options for estimation one by one, some apply to methods nm and mmea, others to mmea only
-  #
-  # Input
-  #
-  # * no input: print values to screen
-  # * one input:
-  #
-  #    'default': sets options at default values
-  #     any other key (see below): print value to screen
-  #
-  # * two inputs
-  #
-  #    'loss_function': 
-  #      'sb': multiplicative symmetric bounded (default)
-  #      'su': multiplicative symmetric unbounded
-  #      're': relative error (not recommanded)
-  #      'SMAE': symmetric mean absolute error
-  #
-  #    'filter': 
-  #      0: do not use filters;
-  #      1: use filters (default)
-  #
-  #    'pars_init_method':
-  #      0: get initial estimates from automatized computation 
-  #      1: read initial estimates from .mat file (for continuation)
-  #      2: read initial estimates from pars_init file (default)
-  #
-  #    'results_output':
-  #      0     - only saves data to .mat (no printing to html or screen and no figures) - use this for (automatic) continuations 
-  #      1, -1 - no saving to .mat file, prints results to html (1) or screen (-1), shows figures but does not save them
-  #      2, -2 - saves to .mat file, prints results to html (2) or screen (-2), shows figures but does not save them
-  #      3, -3 - like 2 (or -2), but also prints graphs to .png files (default is 3)
-  #      4, -4 - like 3 (or -3), but also prints html with implied traits
-  #      5, -5 - like 4 (or -4), but includes related species in the implied traits
-  #      6     - like 5, but also prints html with population traits
-  #   
-  #    'method': 
-  #      'no': do not estimate
-  #      'nm': Nelder-Mead simplex method (default)
-  #      'mmea': multimodal evolutionary algorithm
-  #
-  #    'max_fun_evals': maximum number of function evaluations (default 10000)
-  #
-  #    'report': 
-  #       0 - do not report
-  #       1 - report steps to screen (default)
-  #
-  #    'max_step_number': maximum number of steps (default 500)
-  #
-  #    'tol_simplex': tolerance for how close the simplex points must be together to call them the same (default 1e-4)
-  #
-  #    'tol_fun': tolerance for how close the loss-function values must be together to call them the same (default 1e-4)
-  #
-  #    'simplex_size': fraction added (subtracted if negative) to the free parameters when building the simplex (default 0.05)
-  #
-  #    'search_method' (method mmea only): 
-  #      'mm_shade' - use mm_shade method (default)
-  #     
-  #    'num_results' (method mmea only): The size for the multimodal algorithm's population. The author recommended
-  #       50 for mm_shade ('search_method mm_shade', default) 
-  #       18 * number of free parameters for L-mm_shade ('search method l-mm_shade')
-  #
-  #    'gen_factor' (method mmea only): percentage to build the ranges for initializing the first population of individuals (default 0.5)                  
-  #
-  #    'bounds_from_ind' (method mmea only): 
-  #      0: use ranges from pseudodata if exist (these ranges not existing will be taken from data)         
-  #      1: use ranges from data (default) 
-  #
-  #    'max_calibration_time' (method mmea only): maximum calibration time in minutes (default 30)
-  #    'min_convergence_threshold' (method mmea only): the minimum improvement the mmea needs to reach 
-  #                                                    to continue the calibration process (default 1e-4)
-  #    'max_pop_dist': the maximum distance allowed between the solutions of the MMEA population to 
-  #                     continue the calibration process (default 0.2). 
-  #    'num_runs' (method mmea only): the number of independent runs to perform (default 1)
-  #
-  #    'add_initial' (method mmea only): if the initial individual is added in the first  population.
-  #      1: activated
-  #      0: not activated (default)
-  #
-  #     
-  #    'refine_best'  (method mmea only): if the best individual found is refined using Nelder-Mead.
-  #      0: not activated (default)
-  #      1: activated
-  #     
-  #    'verbose_options' (method mmea only): The number of solutions to show from the set of optimal solutions found by the algorithm through the calibration process (default 10)                                           
-  #
-  #    'verbose' (method mmea only): prints some information while the calibration  process is running              
-  #       0: not activated (default)
-  #       1: activated
-  #
-  #    'seed_index' (method mmea only): index of vector with values for the seeds used to generate random values 
-  #       each one is used in a single run of the algorithm (default 1, must be between 1 and 30)
-  #
-  #    'ranges' (method mmea only): Structure with ranges for the parameters to be calibrated (default empty)
-  #       one value (factor between [0, 1], if not: 0.01 is set) to increase and decrease the original parameter values.
-  #       two values (min, max) for the  minimum and maximum range values. Consider:               
-  #         (1) Use min < max for each variable in ranges. If it is not, then the range will be not used
-  #         (2) Do not take max/min too high, use the likely ranges of the problem
-  #         (3) Only the free parameters (see 'pars_init_my_pet' file) are considered
-  #       Set range with cell string of name of parameter and value for range, e.g. estim_options('ranges',{'kap', [0.3 1]}} 
-  #       Remove range-specification with e.g. estim_options('ranges', {'kap'}} or estim_options('ranges', 'kap'}
-  #
-  #    'results_display (method mmea only)': 
-  #       Basic - Does not show results in screen (default) 
-  #       Best  - Plots the best solution results in DEBtool style
-  #       Set   - Plots all the solutions remarking the best one 
-  #               html with pars (best pars and a measure of the variance of each parameter in the solutions obtained for example)
-  #       Complete - Joins all options with zero variate data with input and a measure of the variance of all the solutions considered
-  #
-  #    'results_filename (method mmea only)': The name for the results file (solutionSet_my_pet_time) 
-  #
-  #    'save_results' (method mmea only): If the results output images are going to be saved
-  #       0: no saving (default)
-  #       1: saving
-  #
-  #    'mat_file' (method mmea only): The name of the .mat-file with results from where to initialize the calibration parameters 
-  #       (only useful if pars_init_method option is equal to 1 and if there is a result file)
-  #       This file is outputted as results_my_pet.mat ("my pet" replaced by name of species) using method nm, results_output 0, 2-6.
-  #
-  #    'sigma_share': The value of the sigma share parameter (that is used
-  #       into the fitness sharing niching method if it is activated)
-  #
-  # Output
-  #
-  # * no output, but globals are set to values or values are printed to screen
-  #
-  ## Remarks
-  # See <estim_pars.html *estim_pars*> for application of the option settings.
-  # Initial estimates are controlled by option 'pars_init_method', but the free-setting is always taken from the pars_init file.
-  # A typical estimation procedure is
-  # 
-  # * first use estim_options('pars_init_method',2) with estim_options('max_step_number',500),
-  # * then estim_options('pars_init_method',1), repeat till satiation or convergence (using arrow-up + enter)
-  # * type mat2pars_init in the Matlab's command window to copy the results in the .mat file to the pars_init file
-  #
-  # If results_output equals 5 or higher, the comparison species can be
-  # specified by declaring variable refPets as global and fill it with a
-  # cell-string of AmP species names.
-  #
-  # The default setting for max_step_number on 500 in method nm is on purpose not enough to reach convergence.
-  # Continuation (using arrow-up + 'enter' after 'pars_init_method' set on 1) is important to restore simplex size.
-  #
-  # Typical simplex options are also used in the evolutionary algorithm via local_search in mm_shade and lmm_shade
-  #
-  ## Example of use
-  #  estim_options('default'); estim_options('filter', 0); estim_options('method', 'no')
-  
-  function estim_options(key::String)
+#  created at 2015/01/25 by Goncalo Marques; 
+#  modified 2015/03/26 by Goncalo Marques, 2018/05/21, 2018/08/21 by Bas Kooijman, 
+#    2019/12/20 by Nina Marn, 2021/06/07 by Bas Kooijman & Juan Robles,
+#    2021/10/20, 2022/04/24 by Juan Robles
 
-    global method, lossfunction, filter, pars_init_method, results_output, max_fun_evals 
-    global report, max_step_number, tol_simplex, tol_fun, simplex_size 
+## Syntax
+# <../estim_options.m *estim_options*> (key, val)
+
+## Description
+# Sets options for estimation one by one, some apply to methods nm and mmea, others to mmea only
+#
+# Input
+#
+# * no input: print values to screen
+# * one input:
+#
+#    'default': sets options at default values
+#     any other key (see below): print value to screen
+#
+# * two inputs
+#
+#    'loss_function': 
+#      'sb': multiplicative symmetric bounded (default)
+#      'su': multiplicative symmetric unbounded
+#      're': relative error (not recommanded)
+#      'SMAE': symmetric mean absolute error
+#
+#    'filter': 
+#      0: do not use filters;
+#      1: use filters (default)
+#
+#    'pars_init_method':
+#      0: get initial estimates from automatized computation 
+#      1: read initial estimates from .mat file (for continuation)
+#      2: read initial estimates from pars_init file (default)
+#
+#    'results_output':
+#      0     - only saves data to .mat (no printing to html or screen and no figures) - use this for (automatic) continuations 
+#      1, -1 - no saving to .mat file, prints results to html (1) or screen (-1), shows figures but does not save them
+#      2, -2 - saves to .mat file, prints results to html (2) or screen (-2), shows figures but does not save them
+#      3, -3 - like 2 (or -2), but also prints graphs to .png files (default is 3)
+#      4, -4 - like 3 (or -3), but also prints html with implied traits
+#      5, -5 - like 4 (or -4), but includes related species in the implied traits
+#      6     - like 5, but also prints html with population traits
+#   
+#    'method': 
+#      'no': do not estimate
+#      'nm': Nelder-Mead simplex method (default)
+#      'mmea': multimodal evolutionary algorithm
+#
+#    'max_fun_evals': maximum number of function evaluations (default 10000)
+#
+#    'report': 
+#       0 - do not report
+#       1 - report steps to screen (default)
+#
+#    'max_step_number': maximum number of steps (default 500)
+#
+#    'tol_simplex': tolerance for how close the simplex points must be together to call them the same (default 1e-4)
+#
+#    'tol_fun': tolerance for how close the loss-function values must be together to call them the same (default 1e-4)
+#
+#    'simplex_size': fraction added (subtracted if negative) to the free parameters when building the simplex (default 0.05)
+#
+#    'search_method' (method mmea only): 
+#      'mm_shade' - use mm_shade method (default)
+#     
+#    'num_results' (method mmea only): The size for the multimodal algorithm's population. The author recommended
+#       50 for mm_shade ('search_method mm_shade', default) 
+#       18 * number of free parameters for L-mm_shade ('search method l-mm_shade')
+#
+#    'gen_factor' (method mmea only): percentage to build the ranges for initializing the first population of individuals (default 0.5)                  
+#
+#    'bounds_from_ind' (method mmea only): 
+#      0: use ranges from pseudodata if exist (these ranges not existing will be taken from data)         
+#      1: use ranges from data (default) 
+#
+#    'max_calibration_time' (method mmea only): maximum calibration time in minutes (default 30)
+#    'min_convergence_threshold' (method mmea only): the minimum improvement the mmea needs to reach 
+#                                                    to continue the calibration process (default 1e-4)
+#    'max_pop_dist': the maximum distance allowed between the solutions of the MMEA population to 
+#                     continue the calibration process (default 0.2). 
+#    'num_runs' (method mmea only): the number of independent runs to perform (default 1)
+#
+#    'add_initial' (method mmea only): if the initial individual is added in the first  population.
+#      1: activated
+#      0: not activated (default)
+#
+#     
+#    'refine_best'  (method mmea only): if the best individual found is refined using Nelder-Mead.
+#      0: not activated (default)
+#      1: activated
+#     
+#    'verbose_options' (method mmea only): The number of solutions to show from the set of optimal solutions found by the algorithm through the calibration process (default 10)                                           
+#
+#    'verbose' (method mmea only): prints some information while the calibration  process is running              
+#       0: not activated (default)
+#       1: activated
+#
+#    'seed_index' (method mmea only): index of vector with values for the seeds used to generate random values 
+#       each one is used in a single run of the algorithm (default 1, must be between 1 and 30)
+#
+#    'ranges' (method mmea only): Structure with ranges for the parameters to be calibrated (default empty)
+#       one value (factor between [0, 1], if not: 0.01 is set) to increase and decrease the original parameter values.
+#       two values (min, max) for the  minimum and maximum range values. Consider:               
+#         (1) Use min < max for each variable in ranges. If it is not, then the range will be not used
+#         (2) Do not take max/min too high, use the likely ranges of the problem
+#         (3) Only the free parameters (see 'pars_init_my_pet' file) are considered
+#       Set range with cell string of name of parameter and value for range, e.g. estim_options('ranges',{'kap', [0.3 1]}} 
+#       Remove range-specification with e.g. estim_options('ranges', {'kap'}} or estim_options('ranges', 'kap'}
+#
+#    'results_display (method mmea only)': 
+#       Basic - Does not show results in screen (default) 
+#       Best  - Plots the best solution results in DEBtool style
+#       Set   - Plots all the solutions remarking the best one 
+#               html with pars (best pars and a measure of the variance of each parameter in the solutions obtained for example)
+#       Complete - Joins all options with zero variate data with input and a measure of the variance of all the solutions considered
+#
+#    'results_filename (method mmea only)': The name for the results file (solutionSet_my_pet_time) 
+#
+#    'save_results' (method mmea only): If the results output images are going to be saved
+#       0: no saving (default)
+#       1: saving
+#
+#    'mat_file' (method mmea only): The name of the .mat-file with results from where to initialize the calibration parameters 
+#       (only useful if pars_init_method option is equal to 1 and if there is a result file)
+#       This file is outputted as results_my_pet.mat ("my pet" replaced by name of species) using method nm, results_output 0, 2-6.
+#
+#    'sigma_share': The value of the sigma share parameter (that is used
+#       into the fitness sharing niching method if it is activated)
+#
+# Output
+#
+# * no output, but globals are set to values or values are printed to screen
+#
+## Remarks
+# See <estim_pars.html *estim_pars*> for application of the option settings.
+# Initial estimates are controlled by option 'pars_init_method', but the free-setting is always taken from the pars_init file.
+# A typical estimation procedure is
+# 
+# * first use estim_options('pars_init_method',2) with estim_options('max_step_number',500),
+# * then estim_options('pars_init_method',1), repeat till satiation or convergence (using arrow-up + enter)
+# * type mat2pars_init in the Matlab's command window to copy the results in the .mat file to the pars_init file
+#
+# If results_output equals 5 or higher, the comparison species can be
+# specified by declaring variable refPets as global and fill it with a
+# cell-string of AmP species names.
+#
+# The default setting for max_step_number on 500 in method nm is on purpose not enough to reach convergence.
+# Continuation (using arrow-up + 'enter' after 'pars_init_method' set on 1) is important to restore simplex size.
+#
+# Typical simplex options are also used in the evolutionary algorithm via local_search in mm_shade and lmm_shade
+#
+## Example of use
+#  estim_options('default'); estim_options('filter', 0); estim_options('method', 'no')
+
+function estim_options(key::String)
+
+    global method, lossfunction, filter, pars_init_method, results_output, max_fun_evals
+    global report, max_step_number, tol_simplex, tol_fun, simplex_size
     global search_method, num_results, gen_factor, factor_type, bounds_from_ind # method mmea only
     global max_calibration_time, num_runs, add_initial, refine_best
     global verbose, verbose_options
     global random_seeds, seed_index, ranges, mat_file, results_display
     global results_filename, save_results, sigma_share
 
-    availableMethodOptions = ["no", "nm", "mmea", "nr"];
+    availableMethodOptions = ["no", "nm", "mmea", "nr"]
 
     #if exist("key","var") == 0
     #  key = "inexistent";
     #end
 
     if key == "default"
-    lossfunction = "sb";
-    filter = 1;
-    pars_init_method  = 2;
-    results_output = 3;
-    method = "nm";
-    max_fun_evals = 1e4;
-    report = 1;
-    max_step_number = 500;
-    tol_simplex = 1e-4;
-    tol_fun = 1e-4;
-    simplex_size = 0.05;
+        lossfunction = "sb"
+        filter = 1
+        pars_init_method = 2
+        results_output = 3
+        method = "nm"
+        max_fun_evals = 1e4
+        report = 1
+        max_step_number = 500
+        tol_simplex = 1e-4
+        tol_fun = 1e-4
+        simplex_size = 0.05
 
-    # for mmea method (taken from calibration_options)
-    search_method = "mm_shade"; # Use mm_shade: Success-History based Adaptive Differential Evolution 
-    num_results = 50;   # The size for the multimodal algorithm's population.
-                         # If not defined then sets the values recommended by the author, 
-                         # which are 100 for mm_shade ('mm_shade') and 18 * problem size for L-mm_shade.
-    gen_factor = 0.5;    # Percentage bounds for individual 
-                         # initialization. (e.g. A value of 0.9 means that, for a parameter value of 1, 
-                         # the range for generation is [(1 - 0.9) * 1, 1 * (1 + 0.9)] so
-                         # the new parameter value will be a random between [0.1, 1.9]
-    factor_type = "mult"; # The kind of factor to be applied when generatin individuals 
-                         #('mult' is multiplicative (Default) | 'add' if
-                         # additive);
-    bounds_from_ind = 1; # This options selects from where the parameters for the initial population of individuals are taken. 
-                         # If the value is equal to 1 the parameters are generated from the data initial values 
-                         # if is 0 then the parameters are generated from the pseudo data values. 
-    add_initial = 0;     # If to add an invidivual taken from initial data into first population.                     # (only if it the 'add_initial' option is activated)
-    refine_best = 0;     # If a local search is applied to the best individual found. 
-    max_calibration_time = 30; # The maximum calibration time calibration process. 
-    num_runs = 5; # The number of runs to perform. 
-    verbose = 0;  # If to print some information while the calibration process is running. 
-    verbose_options = 5; # The number of solutions to show from the  set of optimal solutions found by the  algorithm through the calibration process.
-    random_seeds = [2147483647, 2874923758, 1284092845,  # The values of the seed used to
-                    2783758913, 3287594328, 2328947617,  # generate random values (each one is used in a
-                    1217489374, 1815931031, 3278479237,  # single run of the algorithm).
-                    3342427357, 223758927, 3891375891,  
-                    1781589371, 1134872397, 2784732823, 
-                    2183647447, 24923758, 122845, 
-                    2783784093, 394328, 2328757617, 
-                    12174974, 18593131, 3287237, 
-                    33442757, 2235827, 3837891, 
-                    17159371, 34211397, 2842823]; 
-    seed_index = 1; # index for seeds for random number generator
-    MersenneTwister(random_seeds[seed_index]); # initialize the number generator is with a seed, to be updated for each run of the calibration method.
-    ranges = nothing #struct(); # The range struct is empty by default. 
-    results_display = "Basic"; # The results output style.
-    results_filename = "Default";
-    save_results = false; # If results output are saved.
-    mat_file = "";
-    sigma_share = 0.1;
+        # for mmea method (taken from calibration_options)
+        search_method = "mm_shade" # Use mm_shade: Success-History based Adaptive Differential Evolution 
+        num_results = 50   # The size for the multimodal algorithm's population.
+        # If not defined then sets the values recommended by the author, 
+        # which are 100 for mm_shade ('mm_shade') and 18 * problem size for L-mm_shade.
+        gen_factor = 0.5    # Percentage bounds for individual 
+        # initialization. (e.g. A value of 0.9 means that, for a parameter value of 1, 
+        # the range for generation is [(1 - 0.9) * 1, 1 * (1 + 0.9)] so
+        # the new parameter value will be a random between [0.1, 1.9]
+        factor_type = "mult" # The kind of factor to be applied when generatin individuals 
+        #('mult' is multiplicative (Default) | 'add' if
+        # additive);
+        bounds_from_ind = 1 # This options selects from where the parameters for the initial population of individuals are taken. 
+        # If the value is equal to 1 the parameters are generated from the data initial values 
+        # if is 0 then the parameters are generated from the pseudo data values. 
+        add_initial = 0     # If to add an invidivual taken from initial data into first population.                     # (only if it the 'add_initial' option is activated)
+        refine_best = 0     # If a local search is applied to the best individual found. 
+        max_calibration_time = 30 # The maximum calibration time calibration process. 
+        num_runs = 5 # The number of runs to perform. 
+        verbose = 0  # If to print some information while the calibration process is running. 
+        verbose_options = 5 # The number of solutions to show from the  set of optimal solutions found by the  algorithm through the calibration process.
+        random_seeds = [
+            2147483647,
+            2874923758,
+            1284092845,  # The values of the seed used to
+            2783758913,
+            3287594328,
+            2328947617,  # generate random values (each one is used in a
+            1217489374,
+            1815931031,
+            3278479237,  # single run of the algorithm).
+            3342427357,
+            223758927,
+            3891375891,
+            1781589371,
+            1134872397,
+            2784732823,
+            2183647447,
+            24923758,
+            122845,
+            2783784093,
+            394328,
+            2328757617,
+            12174974,
+            18593131,
+            3287237,
+            33442757,
+            2235827,
+            3837891,
+            17159371,
+            34211397,
+            2842823,
+        ]
+        seed_index = 1 # index for seeds for random number generator
+        MersenneTwister(random_seeds[seed_index]) # initialize the number generator is with a seed, to be updated for each run of the calibration method.
+        ranges = nothing #struct(); # The range struct is empty by default. 
+        results_display = "Basic" # The results output style.
+        results_filename = "Default"
+        save_results = false # If results output are saved.
+        mat_file = ""
+        sigma_share = 0.1
     end
 
-    
+
     if key == "loss_function"
         if length(lossfunction) != 0
-          println("loss_function = ", lossfunction[1]," \n");  
+            println("loss_function = ", lossfunction[1], " \n")
         else
-          println("loss_function = unknown \n");
+            println("loss_function = unknown \n")
         end
-        println("sb - multiplicative symmetric bounded \n");
-        println("su - multiplicative symmetric unbounded \n");
-        println("re - relative error \n");
-        println("SMAE - symmetric mean absolute error \n");
+        println("sb - multiplicative symmetric bounded \n")
+        println("su - multiplicative symmetric unbounded \n")
+        println("re - relative error \n")
+        println("SMAE - symmetric mean absolute error \n")
     end
-      
+
     if key == "filter"
         if length(filter) != 0
-          println("filter = ", filter," \n");  
+            println("filter = ", filter, " \n")
         else
-          println("filter = unknown \n");
+            println("filter = unknown \n")
         end
-        println("0 - do not use filter \n");
-        println("1 - use filter \n");
+        println("0 - do not use filter \n")
+        println("1 - use filter \n")
     end
-      
+
     if key == "pars_init_method"
         if length(pars_init_method) != 0
-          println("pars_init_method = ", pars_init_method," \n");  
+            println("pars_init_method = ", pars_init_method, " \n")
         else
-          println("pars_init_method = unknown \n");
-        end	      
-        println("0 - get initial estimates from automatized computation \n");
-        println("1 - read initial estimates from .mat file \n");
-        println("2 - read initial estimates from pars_init file \n");
+            println("pars_init_method = unknown \n")
+        end
+        println("0 - get initial estimates from automatized computation \n")
+        println("1 - read initial estimates from .mat file \n")
+        println("2 - read initial estimates from pars_init file \n")
     end
 
     if key == "results_output"
         if length(results_output) != 0
-          println("results_output = ", results_output," \n");
+            println("results_output = ", results_output, " \n")
         else
-          println("results_output = unknown \n");
-        end	 
-        println("0      only saves data results to .mat, no figures, no writing to html or screen\n");
-        println("1, -1  no saving to .mat file, prints results to html (1) or screen (-1)\n");
-        println("2, -2  saves to .mat file, prints results to html (2) or screen (-2) \n");
-        println("3, -3  like 2 (or -2), but also prints graphs to .png files (default is 3)\n");
-        println("4, -4  like 3 (or -3), but also prints html with implied traits \n");
-        println("5, -5  like 3 (or -3), but also prints html with implied traits including related species \n");
-        println("6,     like 5, but also prints html with population traits \n");         
+            println("results_output = unknown \n")
+        end
+        println(
+            "0      only saves data results to .mat, no figures, no writing to html or screen\n",
+        )
+        println(
+            "1, -1  no saving to .mat file, prints results to html (1) or screen (-1)\n",
+        )
+        println("2, -2  saves to .mat file, prints results to html (2) or screen (-2) \n")
+        println(
+            "3, -3  like 2 (or -2), but also prints graphs to .png files (default is 3)\n",
+        )
+        println("4, -4  like 3 (or -3), but also prints html with implied traits \n")
+        println(
+            "5, -5  like 3 (or -3), but also prints html with implied traits including related species \n",
+        )
+        println("6,     like 5, but also prints html with population traits \n")
     end
-            
+
     if key == "method"
         if length(method) != 0
-          println("method = ", method," \n");  
+            println("method = ", method, " \n")
         else
-          println("method = unknown \n");
-        end	      
-        println("''no'' - do not estimate \n");
-        println("''nm'' - use Nelder-Mead method \n");
-        println("''mmea'' - use multimodal evolutionary algorithm method \n");
+            println("method = unknown \n")
+        end
+        println("''no'' - do not estimate \n")
+        println("''nm'' - use Nelder-Mead method \n")
+        println("''mmea'' - use multimodal evolutionary algorithm method \n")
     end
 
     if key == "max_fun_evals"
         if length(max_fun_evals) != 0
-          println("max_fun_evals = ", max_fun_evals," \n");  
+            println("max_fun_evals = ", max_fun_evals, " \n")
         else
-          println("max_fun_evals = unknown \n");
-        end	      
+            println("max_fun_evals = unknown \n")
+        end
     end
-      
+
     if key == "report"
         if length(report) != 0
-          println("report = ", report,"\n");  
+            println("report = ", report, "\n")
         else
-          println("report = unknown \n");
-        end	      
-        println("0 - do not report \n");
-        println("1 - do report \n");
+            println("report = unknown \n")
+        end
+        println("0 - do not report \n")
+        println("1 - do report \n")
     end
 
     if key == "max_step_number"
         if length(max_step_number) != 0
-          println("max_step_number = ", max_step_number,"\n");  
+            println("max_step_number = ", max_step_number, "\n")
         else
-          println("max_step_number = unknown \n");
-        end	      
+            println("max_step_number = unknown \n")
+        end
     end
 
     if key == "tol_simplex"
         if length(tol_simplex) != 0
-          println("tol_simplex = ", tol_simplex,"\n");  
+            println("tol_simplex = ", tol_simplex, "\n")
         else
-          println("tol_simplex = unknown \n");
-        end	      
+            println("tol_simplex = unknown \n")
+        end
     end
 
     if key == "simplex_size"
         if length(simplex_size) != 0
-          println("simplex_size = ", simplex_size,"\n");  
+            println("simplex_size = ", simplex_size, "\n")
         else
-          println("simplex_size = unknown \n");
-        end	      
+            println("simplex_size = unknown \n")
+        end
     end
-      
+
     # method mmea only, taken from calibatrion_options
     if key == "search_method"
-        search_method = "mm_shade"; # Select mm_shade as the default method.
-    end 
-      
-    if key == "num_results"
-        if length(num_results) != 0 
-          println("num_results = ", num_results," \n");  
-        else
-          println("num_results = unknown \n");
-        end	      
+        search_method = "mm_shade" # Select mm_shade as the default method.
     end
-      
+
+    if key == "num_results"
+        if length(num_results) != 0
+            println("num_results = ", num_results, " \n")
+        else
+            println("num_results = unknown \n")
+        end
+    end
+
     if key == "gen_factor"
         if length(gen_factor) != 0.0
-          println("gen_factor = ", gen_factor," \n");  
+            println("gen_factor = ", gen_factor, " \n")
         else
-          println("gen_factor = unknown \n");
-        end	      
+            println("gen_factor = unknown \n")
+        end
     end
-      
+
     if key == "factor_type"
-        factor_type = "mult";
-        println("factor_type = ", factor_type," \n");  
-    end	 
-      
+        factor_type = "mult"
+        println("factor_type = ", factor_type, " \n")
+    end
+
     if key == "bounds_from_ind"
         if length(bounds_from_ind) != 0
-          println("bounds_from_ind = ", bounds_from_ind," \n");  
+            println("bounds_from_ind = ", bounds_from_ind, " \n")
         else
-          println("bounds_from_ind = unknown \n");
-        end	      
+            println("bounds_from_ind = unknown \n")
+        end
     end
-      
+
     if key == "add_initial"
         if length(add_initial) != 0
-          println("add_initial = ", add_initial," \n");  
+            println("add_initial = ", add_initial, " \n")
         else
-          println("add_initial = unknown \n");
-        end	      
+            println("add_initial = unknown \n")
+        end
     end
-      
+
     if key == "refine_best"
         if length(refine_best) != 0
-          println("refine_best = ", refine_best," \n");  
+            println("refine_best = ", refine_best, " \n")
         else
-          println("refine_best = unknown \n");
-        end	      
+            println("refine_best = unknown \n")
+        end
     end
-      
+
     if key == "max_calibration_time"
         if length(max_calibration_time) != 0
-          println("max_calibration_time = ", max_calibration_time," \n");
+            println("max_calibration_time = ", max_calibration_time, " \n")
         else
-          println("max_calibration_time = unkown \n");
+            println("max_calibration_time = unkown \n")
         end
     end
-      
+
     if key == "num_runs"
         if length(num_runs) != 0
-          println("num_runs = ", num_runs," \n");
+            println("num_runs = ", num_runs, " \n")
         else
-          println("num_runs = unkown \n");
+            println("num_runs = unkown \n")
         end
     end
-      
+
     if key == "verbose"
         if length(verbose) != 0
-          println("verbose = ", verbose," \n");
+            println("verbose = ", verbose, " \n")
         else
-          println("verbose = unkown \n");
+            println("verbose = unkown \n")
         end
     end
-      
+
     if key == "verbose_options"
         if length(verbose_options) != 0
-          println("verbose_options = ", verbose_options," \n");
+            println("verbose_options = ", verbose_options, " \n")
         else
-          println("verbose_options = unkown \n");
+            println("verbose_options = unkown \n")
         end
     end
-      
+
     if key == "seed_index"
         if length(random_seeds) != 0
-          println("seed_index = ", seed_index[1]," \n");
+            println("seed_index = ", seed_index[1], " \n")
         else
-          println("seed_index = unkown \n");
+            println("seed_index = unkown \n")
         end
     end
-    MersenneTwister(random_seeds[seed_index]); # initialize the random number generator
-      
+    MersenneTwister(random_seeds[seed_index]) # initialize the random number generator
+
     if key == "ranges"
         if length(ranges) != 0
-          println("ranges = structure with fields: \n");
-          println(ranges);
+            println("ranges = structure with fields: \n")
+            println(ranges)
         else
-          println("ranges = unkown \n");
+            println("ranges = unkown \n")
         end
     end
-      
+
     if key == "results_display"
         if strcmp(results_display, "Basic")
-          println("results_display = ", results_display," \n");
+            println("results_display = ", results_display, " \n")
         elseif strcmp(results_display, "Best")
-          println("results_display = ", results_display," \n");
+            println("results_display = ", results_display, " \n")
         elseif strcmp(results_display, "Set")
-          println("results_display = ", results_display," \n");
+            println("results_display = ", results_display, " \n")
         elseif strcmp(results_display, "Complete")
-          println("results_display = ", results_display," \n");
+            println("results_display = ", results_display, " \n")
         else
-          println("results_display = unkown \n");
+            println("results_display = unkown \n")
         end
     end
-      
+
     if key == "results_filename"
-        results_filename = "Default"; 
+        results_filename = "Default"
     end
-      
+
     if key == "save_results"
         if length(save_results) != 0
-          println("save_results = ", save_results," \n");
+            println("save_results = ", save_results, " \n")
         else
-          println("save_results = unkown \n");
+            println("save_results = unkown \n")
         end
     end
-      
+
     if key == "mat_file"
-        mat_file = [""]; 
+        mat_file = [""]
     end
-         
-      if key == "sigma_share"
-            if length(sigma_share) != 0.0
-               println("sigma_share = ", sigma_share," \n");  
-            else
-               println("sigma_share = unknown \n");
-            end	      
-     end
-         
-    # only a single input
-    if key == "inexistent" 
-      if length(lossfunction) != 0
-        println("loss_function = ", lossfunction," \n");
-      else
-        println("loss_function = unknown \n");
-      end
-      
-      if length(filter) != 0
-        println("filter = ", filter," \n");
-      else
-        println("filter = unknown \n");
-      end
-      
-      if length(pars_init_method) != 0
-        println("pars_init_method = ", pars_init_method," \n");
-      else
-        println("pars_init_method = unknown \n");
-      end
-            
-      if length(results_output) != 0
-        println("results_output = ", results_output," \n");
-      else
-        println("results_output = unknown \n");
-      end
-      
-      if length(method) != 0
-        println("method = ", method," \n");
-        if strcmp(method, "mmea")
-          calibration_options;
+
+    if key == "sigma_share"
+        if length(sigma_share) != 0.0
+            println("sigma_share = ", sigma_share, " \n")
+        else
+            println("sigma_share = unknown \n")
         end
-      else
-        println("method = unknown \n");
-      end
+    end
 
-      if length(max_fun_evals) != 0
-        println("max_fun_evals = ", max_fun_evals," \n");
-      else
-        println("max_fun_evals = unknown \n");
-      end
-      
-      if length(report) != 0
-        println("report = ", report," (method nm)\n");
-      else
-        println("report = unknown \n");
-      end
+    # only a single input
+    if key == "inexistent"
+        if length(lossfunction) != 0
+            println("loss_function = ", lossfunction, " \n")
+        else
+            println("loss_function = unknown \n")
+        end
 
-      if length(max_step_number) != 0
-        println("max_step_number = ", max_step_number," (method nm)\n");
-      else
-        println("max_step_number = unknown \n");
-      end
-      
-      if length(tol_simplex) != 0
-        println("tol_simplex = ", tol_simplex," (method nm)\n");
-      else
-        println("tol_simplex = unknown \n");
-      end
-      
-      if length(simplex_size) != 0
-        println("simplex_size = ", simplex_size," (method nm)\n");
-      else
-        println("simplex_size = unknown \n");
-      end
-      
-      # method mmea only
-      if length(search_method) != 0
-        println("search_method = ", search_method," (method mmea)\n");
-      else
-        println("search_method = unkown \n");
-      end
-      
-      if length(num_results) != 0.0
-        println("num_results = ", num_results," (method mmea)\n");
-      else
-        println("num_results = unknown \n");
-      end
-      
-      if length(gen_factor) != 0.0
-        println("gen_factor = ", gen_factor," (method mmea)\n");
-      else
-        println("gen_factor = unknown \n");
-      end
-      
-      if length(factor_type) != 0
-        println("factor_type = ", factor_type," \n");
-      else
-        println("factor_type = unkown \n");
-      end
-      
-      if length(bounds_from_ind) != 0.0
-        println("bounds_from_ind = ", bounds_from_ind," (method mmea)\n");
-      else
-        println("bounds_from_ind = unknown \n");
-      end
-      
-      if length(max_fun_evals) != 0
-        println("max_fun_evals = ", max_fun_evals," (method mmea)\n");
-      else
-        println("max_fun_evals = unkown \n");
-      end
-      
-      if length(max_calibration_time) != 0
-        println("max_calibration_time = ", max_calibration_time," (method mmea)\n");
-      else
-        println("max_calibration_time = unkown \n");
-      end
-      
-      if length(num_runs) != 0
-        println("num_runs = ", num_runs," (method mmea)\n");
-      else
-        println("num_runs = unkown \n");
-      end
-      
-      if length(add_initial) != 0
-        println("add_initial = ", add_initial," (method mmea)\n");
-      else
-        println("add_initial = unkown \n");
-      end
-      
-      if length(refine_best) != 0
-        println("refine_best = ", refine_best," (method mmea)\n");
-      else
-        println("refine_best = unkown \n");
-      end
-      
-      if length(verbose) != 0
-        println("verbose = ", verbose," (method mmea)\n");
-      else
-        println("verbose = unkown \n");
-      end
-      
-      if length(verbose_options) != 0
-        println("verbose_options = ", verbose_options," (method mmea)\n");
-      else
-        println("verbose_options = unkown \n");
-      end
-      
-      if length(random_seeds) != 0
-        println("random_seeds = ", random_seeds[1]," (method mmea)\n");
-      else
-        println("random_seeds = unkown \n");
-      end
-      
-      if length(ranges) != 0 
-        println("ranges = structure with fields (method mmea)\n");
-        disp(struct2table(ranges));
-      else
-        println("ranges = unkown \n");
-      end
-      
-      if strcmp(results_display, "") != 0
-        println("results_display = ", results_display," (method mmea)\n");
-      else
-        println("results_display = unkown \n");
-      end
-      
-      if strcmp(results_filename, "") != 0
-        println("results_filename = ", results_filename," (method mmea)\n");
-      else
-        println("results_filename = unkown \n");
-      end
-      
-      if strcmp(mat_file, "") != 0
-        println("mat_file = ", mat_file," (method mmea)\n");
-      else
-        println("mat_file = unkown \n");
-      end
-      
-      if strcmp(sigma_share, "") != 0
-        println("sigma_share = ", sigma_share," \n");
-      else
-        println("sigma_share = unkown \n");
-      end
-      
-    otherwise
-        println("key ", key, " is unkown \n\n");
-        estim_options;
-  end
-  
-  ## warnings
-  if method =="mmea" && filter==0
-    println("Warning from estim_options: method mmea without using filters amounts to asking for trouble\n");
-  end
+        if length(filter) != 0
+            println("filter = ", filter, " \n")
+        else
+            println("filter = unknown \n")
+        end
+
+        if length(pars_init_method) != 0
+            println("pars_init_method = ", pars_init_method, " \n")
+        else
+            println("pars_init_method = unknown \n")
+        end
+
+        if length(results_output) != 0
+            println("results_output = ", results_output, " \n")
+        else
+            println("results_output = unknown \n")
+        end
+
+        if length(method) != 0
+            println("method = ", method, " \n")
+            if strcmp(method, "mmea")
+                calibration_options
+            end
+        else
+            println("method = unknown \n")
+        end
+
+        if length(max_fun_evals) != 0
+            println("max_fun_evals = ", max_fun_evals, " \n")
+        else
+            println("max_fun_evals = unknown \n")
+        end
+
+        if length(report) != 0
+            println("report = ", report, " (method nm)\n")
+        else
+            println("report = unknown \n")
+        end
+
+        if length(max_step_number) != 0
+            println("max_step_number = ", max_step_number, " (method nm)\n")
+        else
+            println("max_step_number = unknown \n")
+        end
+
+        if length(tol_simplex) != 0
+            println("tol_simplex = ", tol_simplex, " (method nm)\n")
+        else
+            println("tol_simplex = unknown \n")
+        end
+
+        if length(simplex_size) != 0
+            println("simplex_size = ", simplex_size, " (method nm)\n")
+        else
+            println("simplex_size = unknown \n")
+        end
+
+        # method mmea only
+        if length(search_method) != 0
+            println("search_method = ", search_method, " (method mmea)\n")
+        else
+            println("search_method = unkown \n")
+        end
+
+        if length(num_results) != 0.0
+            println("num_results = ", num_results, " (method mmea)\n")
+        else
+            println("num_results = unknown \n")
+        end
+
+        if length(gen_factor) != 0.0
+            println("gen_factor = ", gen_factor, " (method mmea)\n")
+        else
+            println("gen_factor = unknown \n")
+        end
+
+        if length(factor_type) != 0
+            println("factor_type = ", factor_type, " \n")
+        else
+            println("factor_type = unkown \n")
+        end
+
+        if length(bounds_from_ind) != 0.0
+            println("bounds_from_ind = ", bounds_from_ind, " (method mmea)\n")
+        else
+            println("bounds_from_ind = unknown \n")
+        end
+
+        if length(max_fun_evals) != 0
+            println("max_fun_evals = ", max_fun_evals, " (method mmea)\n")
+        else
+            println("max_fun_evals = unkown \n")
+        end
+
+        if length(max_calibration_time) != 0
+            println("max_calibration_time = ", max_calibration_time, " (method mmea)\n")
+        else
+            println("max_calibration_time = unkown \n")
+        end
+
+        if length(num_runs) != 0
+            println("num_runs = ", num_runs, " (method mmea)\n")
+        else
+            println("num_runs = unkown \n")
+        end
+
+        if length(add_initial) != 0
+            println("add_initial = ", add_initial, " (method mmea)\n")
+        else
+            println("add_initial = unkown \n")
+        end
+
+        if length(refine_best) != 0
+            println("refine_best = ", refine_best, " (method mmea)\n")
+        else
+            println("refine_best = unkown \n")
+        end
+
+        if length(verbose) != 0
+            println("verbose = ", verbose, " (method mmea)\n")
+        else
+            println("verbose = unkown \n")
+        end
+
+        if length(verbose_options) != 0
+            println("verbose_options = ", verbose_options, " (method mmea)\n")
+        else
+            println("verbose_options = unkown \n")
+        end
+
+        if length(random_seeds) != 0
+            println("random_seeds = ", random_seeds[1], " (method mmea)\n")
+        else
+            println("random_seeds = unkown \n")
+        end
+
+        if length(ranges) != 0
+            println("ranges = structure with fields (method mmea)\n")
+            disp(struct2table(ranges))
+        else
+            println("ranges = unkown \n")
+        end
+
+        if strcmp(results_display, "") != 0
+            println("results_display = ", results_display, " (method mmea)\n")
+        else
+            println("results_display = unkown \n")
+        end
+
+        if strcmp(results_filename, "") != 0
+            println("results_filename = ", results_filename, " (method mmea)\n")
+        else
+            println("results_filename = unkown \n")
+        end
+
+        if strcmp(mat_file, "") != 0
+            println("mat_file = ", mat_file, " (method mmea)\n")
+        else
+            println("mat_file = unkown \n")
+        end
+
+        if strcmp(sigma_share, "") != 0
+            println("sigma_share = ", sigma_share, " \n")
+        else
+            println("sigma_share = unkown \n")
+        end
+
+        otherwise
+        println("key ", key, " is unkown \n\n")
+        estim_options
+    end
+
+    ## warnings
+    if method == "mmea" && filter == 0
+        println(
+            "Warning from estim_options: method mmea without using filters amounts to asking for trouble\n",
+        )
+    end
 end
 
 
 function estim_options(key::String, val)
 
-    global method, lossfunction, filter, pars_init_method, results_output, max_fun_evals 
-    global report, max_step_number, tol_simplex, tol_fun, simplex_size 
+    global method, lossfunction, filter, pars_init_method, results_output, max_fun_evals
+    global report, max_step_number, tol_simplex, tol_fun, simplex_size
     global search_method, num_results, gen_factor, factor_type, bounds_from_ind # method mmea only
     global max_calibration_time, num_runs, add_initial, refine_best
     global verbose, verbose_options
     global random_seeds, seed_index, ranges, mat_file, results_display
     global results_filename, save_results, sigma_share
 
-    availableMethodOptions = ["no", "nm", "mmea", "nr"];
+    availableMethodOptions = ["no", "nm", "mmea", "nr"]
 
     #if exist("key","var") == 0
     #  key = "inexistent";
     #end
 
     if key == "loss_function"
-        lossfunction[1] = val;
+        lossfunction[1] = val
     end
-      
+
     if key == "filter"
-        filter = val;
-      end
-      
+        filter = val
+    end
+
     if key == "pars_init_method"
-        pars_init_method = val;
-      end
+        pars_init_method = val
+    end
 
     if key == "results_output"
-        results_output = val;
-      end
-            
+        results_output = val
+    end
+
     if key == "method"
-        method = val;
-      end
+        method = val
+    end
 
     if key == "max_fun_evals"
-        max_fun_evals = val;
-        max_calibration_time = Inf; # mmea method only
-      end
-      
+        max_fun_evals = val
+        max_calibration_time = Inf # mmea method only
+    end
+
     if key == "report"
-        report = val;
+        report = val
     end
 
     if key == "max_step_number"
-        max_step_number = val;
-      end
+        max_step_number = val
+    end
 
     if key == "tol_simplex"
-        tol_simplex = val;
-      end
+        tol_simplex = val
+    end
 
     if key == "simplex_size"
-        simplex_size = val;
-      end
-      
+        simplex_size = val
+    end
+
     # method mmea only, taken from calibatrion_options
     if key == "search_method"
-        search_method = val;
-      end 
-      
-    if key == "num_results"
-        if num_results < 1 
-          num_results = 10;
-        else
-          num_results = val;
-        end
-      end
-      
-    if key == "gen_factor"
-        gen_factor = val;
-      end
-      
-    if key == "factor_type"
-          factor_type = val;
-      end	 
-      
-    if key == "bounds_from_ind"
-        bounds_from_ind = val;
-      end
-      
-    if key == "add_initial"
-        add_initial = val;
-      end
-      
-    if key == "refine_best"
-        refine_best = val;
-      end
-      
-    if key == "max_calibration_time"
-        max_calibration_time = val;
-        max_fun_evals = Inf;
-      end
-      
-    if key == "num_runs"
-        num_runs = val;
-      end
-      
-    if key == "verbose"
-        verbose = val;
-      end
-      
-    if key == "verbose_options"
-        verbose_options = val;
-      end
-      
-    if key == "seed_index"
-        seed_index = val;
-      rng(random_seeds(seed_index), "twister"); # initialize the random number generator
+        search_method = val
     end
-    
+
+    if key == "num_results"
+        if num_results < 1
+            num_results = 10
+        else
+            num_results = val
+        end
+    end
+
+    if key == "gen_factor"
+        gen_factor = val
+    end
+
+    if key == "factor_type"
+        factor_type = val
+    end
+
+    if key == "bounds_from_ind"
+        bounds_from_ind = val
+    end
+
+    if key == "add_initial"
+        add_initial = val
+    end
+
+    if key == "refine_best"
+        refine_best = val
+    end
+
+    if key == "max_calibration_time"
+        max_calibration_time = val
+        max_fun_evals = Inf
+    end
+
+    if key == "num_runs"
+        num_runs = val
+    end
+
+    if key == "verbose"
+        verbose = val
+    end
+
+    if key == "verbose_options"
+        verbose_options = val
+    end
+
+    if key == "seed_index"
+        seed_index = val
+        rng(random_seeds(seed_index), "twister") # initialize the random number generator
+    end
+
     # MK need to fix this
     # if key == "ranges"
     #     if iscell(val) && length(val)>1
@@ -777,34 +809,36 @@ function estim_options(key::String, val)
     #       ranges = rmfield(ranges, val);
     #     end
     #   end
-      
+
     if key == "results_display"
-        results_display = val;
-      end
-      
+        results_display = val
+    end
+
     if key == "results_filename"
-        results_filename = val;
-      end
-      
+        results_filename = val
+    end
+
     if key == "save_results"
-        save_results = val;
-      end
-      
+        save_results = val
+    end
+
     if key == "mat_file"
-        mat_file = val;
-      end
-         
-      if key == "sigma_share"
-            if val > 1.0
-               val = 1.0;
-            elseif val < 0.0
-               val = .0;
-            end
-            sigma_share = val;
-         end
- 
-  ## warnings
-  if method == "mmea" && filter==0
-    println("Warning from estim_options: method mmea without using filters amounts to asking for trouble\n");
-  end
+        mat_file = val
+    end
+
+    if key == "sigma_share"
+        if val > 1.0
+            val = 1.0
+        elseif val < 0.0
+            val = 0.0
+        end
+        sigma_share = val
+    end
+
+    ## warnings
+    if method == "mmea" && filter == 0
+        println(
+            "Warning from estim_options: method mmea without using filters amounts to asking for trouble\n",
+        )
+    end
 end

--- a/src/lib/pet/estim_pars.jl
+++ b/src/lib/pet/estim_pars.jl
@@ -5,212 +5,217 @@
 #function estim_pars(pets, pars_init_method, method, filter, covRules)
 function estim_pars(pets = ["Emydura_macquarii"], par_model = par_model, metaPar = metaPar)
 
-  # created 2015/02/10 by Goncalo Marques
-  # modified 2015/02/10 by Bas Kooijman, 
-  #   2015/03/31, 2015/shade07/30, 2017/02/03 by Goncalo Marques, 
-  #   2018/05/23 by Bas Kooijman,  
-  #   2018/08/17 by Starrlight Augustine,
-  #   2019/03/20, 2019/12/16, 2019/12/20, 2021/06/02 by Bas kooijman
+    # created 2015/02/10 by Goncalo Marques
+    # modified 2015/02/10 by Bas Kooijman, 
+    #   2015/03/31, 2015/shade07/30, 2017/02/03 by Goncalo Marques, 
+    #   2018/05/23 by Bas Kooijman,  
+    #   2018/08/17 by Starrlight Augustine,
+    #   2019/03/20, 2019/12/16, 2019/12/20, 2021/06/02 by Bas kooijman
 
-  ## Syntax 
-  # [nsteps, info, fval] = <../estim_pars.m *estim_pars*>
+    ## Syntax 
+    # [nsteps, info, fval] = <../estim_pars.m *estim_pars*>
 
-  ## Description
-  # Runs the entire estimation procedure, see Marques et al 2018, PLOS computational biology  https://doi.org/10.1371/journal.pcbi.1006100
-  # See also Robles et al 2021, (in prep) for the ea-method.
-  # 
-  #
-  # * gets the parameters
-  # * gets the data
-  # * initiates the estimation procedure
-  # * sends the results for handling
-  #
-  # Input
-  #
-  # * no input
-  #  
-  # Output
-  #
-  # * nsteps: scalar with number of steps
-  # * info: boolean with succussful convergence (true)
-  # * fval: minimum of loss function
+    ## Description
+    # Runs the entire estimation procedure, see Marques et al 2018, PLOS computational biology  https://doi.org/10.1371/journal.pcbi.1006100
+    # See also Robles et al 2021, (in prep) for the ea-method.
+    # 
+    #
+    # * gets the parameters
+    # * gets the data
+    # * initiates the estimation procedure
+    # * sends the results for handling
+    #
+    # Input
+    #
+    # * no input
+    #  
+    # Output
+    #
+    # * nsteps: scalar with number of steps
+    # * info: boolean with succussful convergence (true)
+    # * fval: minimum of loss function
 
-  ## Remarks
-  # estim_options sets many options;
-  # Option filter = 0 selects filter_nat, which always gives a pass, but
-  # still allows for costomized filters in the predict file;
-  # Option output >= 5 allow the filling of global refPets to choose
-  # comparison species, otherwise this is done automatically.
+    ## Remarks
+    # estim_options sets many options;
+    # Option filter = 0 selects filter_nat, which always gives a pass, but
+    # still allows for costomized filters in the predict file;
+    # Option output >= 5 allow the filling of global refPets to choose
+    # comparison species, otherwise this is done automatically.
 
-  global pets, pars_init_method, method, filter, covRules
-  global parPets, par
+    global pets, pars_init_method, method, filter, covRules
+    global parPets, par
 
-  global pets = ["Emydura_macquarii"];
-  include("predict_Emydura_macquarii.jl")
+    global pets = ["Emydura_macquarii"]
+    include("predict_Emydura_macquarii.jl")
 
-  n_pets = length(pets)
+    n_pets = length(pets)
 
-  # get data
-  #[data, auxData, metaData, txtData, weights] = mydata_pets;
-  data, auxData, metaData, txtData, weights = mydata_pets(pets)
+    # get data
+    #[data, auxData, metaData, txtData, weights] = mydata_pets;
+    data, auxData, metaData, txtData, weights = mydata_pets(pets)
 
-  if n_pets == 1
-    pars_initnm = "pars_init_" * pets[1]
-    resultsnm = "results_" * pets[1] * ".jld2"
-    calibration_options("results_filename", resultsnm)
-  else
-    pars_initnm = "pars_init_group"
-    resultsnm = "results_group.jdl2"
-  end
-
-  # TO DO
-  # set parameters
-  # if pars_init_method == 0
-  #   if n_pets != 1
-  #     error("    For multispecies estimation get_pars cannot be used (pars_init_method cannot be 0)");
-  #   else
-  #     [par, metaPar, txtPar] = get_pars(data.(pets[1]), auxData.(pets[1]), metaData.(pets[1]));
-  #   end
-  # elseif pars_init_method == 1
-  #     load(resultsnm, "par");
-  #     if n_pets == 1
-  #       [par2, metaPar, txtPar] = feval(pars_initnm, metaData.(pets[1]));
-  #     else
-  #       [par2, metaPar, txtPar] = feval(pars_initnm, metaData);
-  #     end
-  #     if length(fieldnames(par.free)) != length(fieldnames(par2.free))
-  #       println("The number of parameters in pars.free in the pars_init and in the .mat file are not the same. \n");
-  #       return;
-  #     end
-  #     par.free = par2.free;
-  # elseif pars_init_method == 2
-  #     if n_pets == 1
-  #include("../example/pars_init_" * pets[1] * ".jl")
-  par_names = fieldnames(typeof(par_model.parent)) # get the field names
-  par_vals = par_model[:val] # get the values
-  par_units = par_model[:units] # get the units
-  par = NamedTuple{par_names}(Tuple([u === nothing ? typeof(v)(v) : v*u for (v, u) in zip(par_vals, par_units)])) # adjoin units to parameter values
-  par_free = NamedTuple{par_names}(par_model[:free]) # get the vector of free parameters
-  par = (par..., free=par_free) # append free parameters to the par struct
-  #       end
-  #       #[par, metaPar, txtPar] = feval(pars_initnm, metaData.(pets[1]));
-  #     else
-  #       [par, metaPar, txtPar] = feval(pars_initnm, metaData);
-  #     end
-  # end
-
-  # make sure that global covRules exists
-  #if exist("metaPar.covRules","var")
-  if isdefined(metaPar, :covRules)
-    covRules = metaPar.covRules
-  else
-    covRules = "no"
-  end
-
-  # TO DO
-  # # set weightsPar in case of n_pets > 1, to minimize scaled variances of parameters
-  # if n_pets > 1
-  #   fldPar = fieldnames(typeof(par.free));
-  #   for i = 1:length(fldPar)
-  #      if isfield(metaPar, "weights") && isfield(metaPar.weights, fldPar[i])
-  #        weightsPar.(fldPar[i]) = metaPar.weights.(fldPar[i]);
-  #      else
-  #        weightsPar.(fldPar[i]) = 0;
-  #      end
-  #   end
-  # end
-
-  # check parameter set if you are using a filter
-  parPets = parGrp2Pets(par) # convert parameter structure of group of pets to cell string for each pet
-  if filter == 1
-    pass = true
-    filternm = n_pets[1]#cell(n_pets,1);
-    for i = 1:n_pets
-      #if ~iscell(metaPar.model) # model is a character string
-      if !isa(metaPar.model, Array)
-        filternm = "filter_" * metaPar.model
-        petnm = pets[i]
-        #[passSpec, flag] = feval(filternm, parPets.(pets[i]));
-        passSpec, flag = eval(Meta.parse("$filternm(parPets.$petnm)"))
-      elseif length(metaPar.model) == 1 # model could have been a character string
-        #filternm = ["filter_", metaPar.model[1]];
-        #[passSpec, flag] = feval(filternm, parPets.(pets[i]));
-        filternm = "filter_" * metaPar.model
-        petnm = pets[1]
-        #[passSpec, flag] = feval(filternm, parPets.(pets[i]));
-        passSpec, flag = eval(Meta.parse("$filternm(parPets.$petnm)"))
-      else # model is a cell string
-        #filternm[i] = ["filter_", metaPar.model[i]];
-        filternm = "filter_" * metaPar.model[i]
-        petnm = pets[i]
-        #[passSpec, flag] = feval(filternm, parPets.(pets[i]));
-        passSpec, flag = eval(Meta.parse("$filternm(parPets.$petnm)"))
-        #[passSpec, flag] = feval(filternm[i], parPets.(pets[i]));
-      end
-      if ~passSpec
-        println("The seed parameter set for " * pets[i] * " is not realistic. \n")
-        print_filterflag(flag)
-      end
-      pass = pass && passSpec
+    if n_pets == 1
+        pars_initnm = "pars_init_" * pets[1]
+        resultsnm = "results_" * pets[1] * ".jld2"
+        calibration_options("results_filename", resultsnm)
+    else
+        pars_initnm = "pars_init_group"
+        resultsnm = "results_group.jdl2"
     end
-    if ~pass
-      error("The seed parameter set is not realistic")
-    end
-  else
-    filternm = "filter_nat" # this filter always gives a pass
-    pass = 1
-  end
 
-  # perform the actual estimation
-  #switch method
-  #  case "nm"
-  if method == "nm"
-    #if n_pets == 1
-    par, info, nsteps, fval = petregr_f("predict_pets", par, data, auxData, weights, filternm)   # estimate parameters using overwrite
-    #else
-    #  [par, info, nsteps, fval] = groupregr_f("predict_pets", par, data, auxData, weights, weightsPar, filternm); # estimate parameters using overwrite
+    # TO DO
+    # set parameters
+    # if pars_init_method == 0
+    #   if n_pets != 1
+    #     error("    For multispecies estimation get_pars cannot be used (pars_init_method cannot be 0)");
+    #   else
+    #     [par, metaPar, txtPar] = get_pars(data.(pets[1]), auxData.(pets[1]), metaData.(pets[1]));
+    #   end
+    # elseif pars_init_method == 1
+    #     load(resultsnm, "par");
+    #     if n_pets == 1
+    #       [par2, metaPar, txtPar] = feval(pars_initnm, metaData.(pets[1]));
+    #     else
+    #       [par2, metaPar, txtPar] = feval(pars_initnm, metaData);
+    #     end
+    #     if length(fieldnames(par.free)) != length(fieldnames(par2.free))
+    #       println("The number of parameters in pars.free in the pars_init and in the .mat file are not the same. \n");
+    #       return;
+    #     end
+    #     par.free = par2.free;
+    # elseif pars_init_method == 2
+    #     if n_pets == 1
+    #include("../example/pars_init_" * pets[1] * ".jl")
+    par_names = fieldnames(typeof(par_model.parent)) # get the field names
+    par_vals = par_model[:val] # get the values
+    par_units = par_model[:units] # get the units
+    par = NamedTuple{par_names}(
+        Tuple([
+            u === nothing ? typeof(v)(v) : v * u for (v, u) in zip(par_vals, par_units)
+        ]),
+    ) # adjoin units to parameter values
+    par_free = NamedTuple{par_names}(par_model[:free]) # get the vector of free parameters
+    par = (par..., free = par_free) # append free parameters to the par struct
+    #       end
+    #       #[par, metaPar, txtPar] = feval(pars_initnm, metaData.(pets[1]));
+    #     else
+    #       [par, metaPar, txtPar] = feval(pars_initnm, metaData);
+    #     end
+    # end
+
+    # make sure that global covRules exists
+    #if exist("metaPar.covRules","var")
+    if isdefined(metaPar, :covRules)
+        covRules = metaPar.covRules
+    else
+        covRules = "no"
+    end
+
+    # TO DO
+    # # set weightsPar in case of n_pets > 1, to minimize scaled variances of parameters
+    # if n_pets > 1
+    #   fldPar = fieldnames(typeof(par.free));
+    #   for i = 1:length(fldPar)
+    #      if isfield(metaPar, "weights") && isfield(metaPar.weights, fldPar[i])
+    #        weightsPar.(fldPar[i]) = metaPar.weights.(fldPar[i]);
+    #      else
+    #        weightsPar.(fldPar[i]) = 0;
+    #      end
+    #   end
+    # end
+
+    # check parameter set if you are using a filter
+    parPets = parGrp2Pets(par) # convert parameter structure of group of pets to cell string for each pet
+    if filter == 1
+        pass = true
+        filternm = n_pets[1]#cell(n_pets,1);
+        for i = 1:n_pets
+            #if ~iscell(metaPar.model) # model is a character string
+            if !isa(metaPar.model, Array)
+                filternm = "filter_" * metaPar.model
+                petnm = pets[i]
+                #[passSpec, flag] = feval(filternm, parPets.(pets[i]));
+                passSpec, flag = eval(Meta.parse("$filternm(parPets.$petnm)"))
+            elseif length(metaPar.model) == 1 # model could have been a character string
+                #filternm = ["filter_", metaPar.model[1]];
+                #[passSpec, flag] = feval(filternm, parPets.(pets[i]));
+                filternm = "filter_" * metaPar.model
+                petnm = pets[1]
+                #[passSpec, flag] = feval(filternm, parPets.(pets[i]));
+                passSpec, flag = eval(Meta.parse("$filternm(parPets.$petnm)"))
+            else # model is a cell string
+                #filternm[i] = ["filter_", metaPar.model[i]];
+                filternm = "filter_" * metaPar.model[i]
+                petnm = pets[i]
+                #[passSpec, flag] = feval(filternm, parPets.(pets[i]));
+                passSpec, flag = eval(Meta.parse("$filternm(parPets.$petnm)"))
+                #[passSpec, flag] = feval(filternm[i], parPets.(pets[i]));
+            end
+            if ~passSpec
+                println("The seed parameter set for " * pets[i] * " is not realistic. \n")
+                print_filterflag(flag)
+            end
+            pass = pass && passSpec
+        end
+        if ~pass
+            error("The seed parameter set is not realistic")
+        end
+    else
+        filternm = "filter_nat" # this filter always gives a pass
+        pass = 1
+    end
+
+    # perform the actual estimation
+    #switch method
+    #  case "nm"
+    if method == "nm"
+        #if n_pets == 1
+        par, info, nsteps, fval =
+            petregr_f("predict_pets", par, data, auxData, weights, filternm)   # estimate parameters using overwrite
+        #else
+        #  [par, info, nsteps, fval] = groupregr_f("predict_pets", par, data, auxData, weights, weightsPar, filternm); # estimate parameters using overwrite
+        #end
+    end
+    #  case "mmea" 
+    # if method == "mmea"# TO DO
+    #   [par, solutions_set, fval] = calibrate; 
+    #   info = ~isempty(solutions_set); 
+    #   nsteps = solutions_set.runtime_information.run_1.fun_evals;
+    # end
+    #case "nr"
+    # if method == "nr"# TO DO
+    #   [par, solutions_set, fval] = calibrate; 
+    #   info = ~isempty(solutions_set); 
+    #   nsteps = solutions_set.runtime_information.fun_evals;
+    # #otherwise # do not estimate
+    # end
     #end
-  end
-  #  case "mmea" 
-  # if method == "mmea"# TO DO
-  #   [par, solutions_set, fval] = calibrate; 
-  #   info = ~isempty(solutions_set); 
-  #   nsteps = solutions_set.runtime_information.run_1.fun_evals;
-  # end
-  #case "nr"
-  # if method == "nr"# TO DO
-  #   [par, solutions_set, fval] = calibrate; 
-  #   info = ~isempty(solutions_set); 
-  #   nsteps = solutions_set.runtime_information.fun_evals;
-  # #otherwise # do not estimate
-  # end
-  #end
 
-  # Results
-  #switch method
-  if method in ["nm", "no"]
-    #  results_pets(par, metaPar, txtPar, data, auxData, metaData, txtData, weights);
-    # elseif method == "mmea" # TO DO
-    #   mmea_name =  strsplit(resultsnm, ".");
-    #   resultsnm = [mmea_name[1], "_mmea.", mmea_name[2]];
-    #   calibration_options("results_filename", resultsnm);
-    #   result_pets_mmea(solutions_set, par, metaPar, txtPar, data, auxData, metaData, txtData, weights);
-    # elseif method == "nr" # TO DO
-    #   mmea_name =  strsplit(resultsnm, ".");
-    #   resultsnm = [mmea_name[1], "_mmea.", mmea_name[2]];
-    #   calibration_options("results_filename", resultsnm);
-    #   result_pets_mmea(solutions_set, par, metaPar, txtPar, data, auxData, metaData, txtData, weights);
-  end
+    # Results
+    #switch method
+    if method in ["nm", "no"]
+        #  results_pets(par, metaPar, txtPar, data, auxData, metaData, txtData, weights);
+        # elseif method == "mmea" # TO DO
+        #   mmea_name =  strsplit(resultsnm, ".");
+        #   resultsnm = [mmea_name[1], "_mmea.", mmea_name[2]];
+        #   calibration_options("results_filename", resultsnm);
+        #   result_pets_mmea(solutions_set, par, metaPar, txtPar, data, auxData, metaData, txtData, weights);
+        # elseif method == "nr" # TO DO
+        #   mmea_name =  strsplit(resultsnm, ".");
+        #   resultsnm = [mmea_name[1], "_mmea.", mmea_name[2]];
+        #   calibration_options("results_filename", resultsnm);
+        #   result_pets_mmea(solutions_set, par, metaPar, txtPar, data, auxData, metaData, txtData, weights);
+    end
 
-  # check filter
-  #parPets = parGrp2Pets(par); # convert parameter structure of group of pets to cell string for each pet
-  #if filter
-  #  for i = 1:n_pets
-  #    if iscell(metaPar.model)
-  #      feval(["warning_", metaPar.model[i]], parPets.(pets[i]));
-  #    else
-  #      feval(["warning_", metaPar.model], parPets.(pets[i]));
-  #    end
-  #  end
-  (nsteps, info, fval)
+    # check filter
+    #parPets = parGrp2Pets(par); # convert parameter structure of group of pets to cell string for each pet
+    #if filter
+    #  for i = 1:n_pets
+    #    if iscell(metaPar.model)
+    #      feval(["warning_", metaPar.model[i]], parPets.(pets[i]));
+    #    else
+    #      feval(["warning_", metaPar.model], parPets.(pets[i]));
+    #    end
+    #  end
+    (nsteps, info, fval)
 end

--- a/src/lib/pet/fieldnm_wtxt.jl
+++ b/src/lib/pet/fieldnm_wtxt.jl
@@ -60,7 +60,7 @@ function fieldnm_wtxt(st, txt)
     while length(fullnmaux) > 0
         nmaux = fieldnames(typeof(getproperty(st, fullnmaux[1])))
         nmaux2 = collect(nmaux)
-        for i in 1:length(nmaux2)
+        for i = 1:length(nmaux2)
             if nmaux2[i] == txt
                 push!(fullnm, join(fullnmaux[1], txt, "."))
             elseif isstruct(getproperty(st, joinpath(fullnmaux[1], nmaux2[i])))

--- a/src/lib/pet/filter_std.jl
+++ b/src/lib/pet/filter_std.jl
@@ -3,92 +3,107 @@
 
 ##
 function filter_std(p)
-# created 2014/01/22 by Bas Kooijman; modified 2015/03/17, 2015/07/29 by Goncalo Marques
-# modified 2015/08/03 by starrlight, 2016/10/25 by Goncalo Marques
+    # created 2014/01/22 by Bas Kooijman; modified 2015/03/17, 2015/07/29 by Goncalo Marques
+    # modified 2015/08/03 by starrlight, 2016/10/25 by Goncalo Marques
 
-## Syntax
-# [filter, flag] = <../filter_std.m *filter_std*> (p)
+    ## Syntax
+    # [filter, flag] = <../filter_std.m *filter_std*> (p)
 
-## Description
-# Checks if parameter values are in the allowable part of the parameter
-#    space of standard DEB model without acceleration
-# Meant to be run in the estimation procedure
-#
-# Input
-#
-# * p: structure with parameters (see below)
-#  
-# Output
-#
-# * filter: 0 for hold, 1 for pass
-# * flag: indicator of reason for not passing the filter
-#
-#     0: parameters pass the filter
-#     1: some parameter is negative
-#     2: some kappa is larger than 1 or smaller than 0
-#     3: growth efficiency is larger than 1
-#     4: maturity levels do not increase during life cycle
-#     5: puberty cannot be reached
+    ## Description
+    # Checks if parameter values are in the allowable part of the parameter
+    #    space of standard DEB model without acceleration
+    # Meant to be run in the estimation procedure
+    #
+    # Input
+    #
+    # * p: structure with parameters (see below)
+    #  
+    # Output
+    #
+    # * filter: 0 for hold, 1 for pass
+    # * flag: indicator of reason for not passing the filter
+    #
+    #     0: parameters pass the filter
+    #     1: some parameter is negative
+    #     2: some kappa is larger than 1 or smaller than 0
+    #     3: growth efficiency is larger than 1
+    #     4: maturity levels do not increase during life cycle
+    #     5: puberty cannot be reached
 
-## Remarks
-#  The theory behind boundaries is discussed in 
-#    <http://www.bio.vu.nl/thb/research/bib/LikaAugu2013.html LikaAugu2013>.
+    ## Remarks
+    #  The theory behind boundaries is discussed in 
+    #    <http://www.bio.vu.nl/thb/research/bib/LikaAugu2013.html LikaAugu2013>.
 
-  filter = false; flag = 0; # default setting of filter and flag
-    
-  parvec = [p.z; p.kap_X; p.kap_P; p.v; p.kap; p.p_M; p.E_G; p.k_J; p.E_Hb; p.E_Hp; p.kap_R; p.h_a; p.T_A];
-  
-  if sum(Unitful.ustrip.(parvec) .<= 0) > 0 # all pars must be positive
-    flag = 1;
-    return(filter, flag);
-    return
-  elseif p.p_T < 0u"J/d/cm^2"
-    flag = 1;
-    return(filter, flag);
-    return
-  end
+    filter = false
+    flag = 0 # default setting of filter and flag
 
-  if p.E_Hb >= p.E_Hp # maturity at birth, puberty
-    flag = 4;
-    return(filter, flag);
-    return;
-  end
+    parvec = [
+        p.z
+        p.kap_X
+        p.kap_P
+        p.v
+        p.kap
+        p.p_M
+        p.E_G
+        p.k_J
+        p.E_Hb
+        p.E_Hp
+        p.kap_R
+        p.h_a
+        p.T_A
+    ]
 
-  if p.f > 1
-    flag = 2;
-    return(filter, flag);
-    return;
-  end
+    if sum(Unitful.ustrip.(parvec) .<= 0) > 0 # all pars must be positive
+        flag = 1
+        return (filter, flag)
+        return
+    elseif p.p_T < 0u"J/d/cm^2"
+        flag = 1
+        return (filter, flag)
+        return
+    end
 
-  parvec = [p.kap; p.kap_R; p.kap_X; p.kap_P];
-  
-  if sum(Unitful.ustrip.(parvec .>= 1)) > 0 
-    flag = 2;
-    return(filter, flag);
-    return;
-  end
+    if p.E_Hb >= p.E_Hp # maturity at birth, puberty
+        flag = 4
+        return (filter, flag)
+        return
+    end
 
-  # compute and unpack cpar (compound parameters)
-  c = parscomp_st(p);
+    if p.f > 1
+        flag = 2
+        return (filter, flag)
+        return
+    end
 
-  if c.kap_G >= 1 # growth efficiency
-    flag = 3;
-    return(filter, flag);    
-    return;
-  end
+    parvec = [p.kap; p.kap_R; p.kap_X; p.kap_P]
 
-  if c.k * c.v_Hp >= p.f * (p.f - c.l_T)^2 # constraint required for reaching puberty
-    flag = 5; 
-    return(filter, flag);   
-    return;
-  end
+    if sum(Unitful.ustrip.(parvec .>= 1)) > 0
+        flag = 2
+        return (filter, flag)
+        return
+    end
 
-  if !reach_birth(c.g, c.k, c.v_Hb, p.f) # constraint required for reaching birth
-    flag = 6;
-    return(filter, flag);    
-    return;
-  end  
-  
-  filter = true;
-  return(filter, flag) 
+    # compute and unpack cpar (compound parameters)
+    c = parscomp_st(p)
+
+    if c.kap_G >= 1 # growth efficiency
+        flag = 3
+        return (filter, flag)
+        return
+    end
+
+    if c.k * c.v_Hp >= p.f * (p.f - c.l_T)^2 # constraint required for reaching puberty
+        flag = 5
+        return (filter, flag)
+        return
+    end
+
+    if !reach_birth(c.g, c.k, c.v_Hb, p.f) # constraint required for reaching birth
+        flag = 6
+        return (filter, flag)
+        return
+    end
+
+    filter = true
+    return (filter, flag)
 end

--- a/src/lib/pet/mydata_pets.jl
+++ b/src/lib/pet/mydata_pets.jl
@@ -5,109 +5,109 @@
 #function [data, auxData, metaData, txtData, weights] = mydata_pets
 function mydata_pets(pets)
     # created by Goncalo Marques at 2015/01/28, modified Bas Kooijman 2021/01/17
-  
-  ## Syntax
-  # [data, auxData, metaData, txtData, weights] = <../mydata_pets.m *mydata_pets*>
-  
-  ## Description
-  # catenates mydata files for several species
-  #
-  # Output
-  #
-  # * data: catenated data structure
-  # * auxData: catenated auxiliary data structure
-  # * txtData: catenated text for data
-  # * metaData: catenated metadata structure
-  # * weights: catenated weights structure
 
- global pets, pseudodata_pets, petnm
-#  ["mydata_" * x for x in pets]
-#  function load_modules(module_names::Vector{String})
-#   for name in module_names
-#       @eval using .$(Symbol(name))
-#   end
-# end
+    ## Syntax
+    # [data, auxData, metaData, txtData, weights] = <../mydata_pets.m *mydata_pets*>
 
-#  # note can't include 'i' in an eval statement - i isn't in the local scope of the evaluation
-#  #expr = Meta.parse("\"mydata_\" * x * \"())\"") # parse the expression wanted
-#  #fdefexpr = :(x -> $(expr)) # make it take x as an argument
-#  #f = eval(fdefexpr) # define the function to evaluate it
-# for i in 1:length("mydata_" * pets) # calls species mydata functions
-#   #[data.(pets{i}), auxData.(pets{i}), metaData.(pets{i}), txtData.(pets{i}), weights.(pets{i})] = eval(:(include("../src/mydata_" * pets[i] * ".jl")));
-#   #f(pets[i])
-#   modName = Meta.parse("mydata_" * pets[1])
-#   #m = :modName
-#   @eval import .$modName
+    ## Description
+    # catenates mydata files for several species
+    #
+    # Output
+    #
+    # * data: catenated data structure
+    # * auxData: catenated auxiliary data structure
+    # * txtData: catenated text for data
+    # * metaData: catenated metadata structure
+    # * weights: catenated weights structure
 
-# @eval import .$m
-#   eval(Symbol(funcname))()
-#   #@get_mydata_pets(pets[i])
-# end  
+    global pets, pseudodata_pets, petnm
+    #  ["mydata_" * x for x in pets]
+    #  function load_modules(module_names::Vector{String})
+    #   for name in module_names
+    #       @eval using .$(Symbol(name))
+    #   end
+    # end
 
-i = 0
-for file_name in ["c:/git/DEBtool_J.jl/example/mydata_" * x * ".jl" for x in pets]
-  i = i + 1
-  include(file_name) # load the mydata file
+    #  # note can't include 'i' in an eval statement - i isn't in the local scope of the evaluation
+    #  #expr = Meta.parse("\"mydata_\" * x * \"())\"") # parse the expression wanted
+    #  #fdefexpr = :(x -> $(expr)) # make it take x as an argument
+    #  #f = eval(fdefexpr) # define the function to evaluate it
+    # for i in 1:length("mydata_" * pets) # calls species mydata functions
+    #   #[data.(pets{i}), auxData.(pets{i}), metaData.(pets{i}), txtData.(pets{i}), weights.(pets{i})] = eval(:(include("../src/mydata_" * pets[i] * ".jl")));
+    #   #f(pets[i])
+    #   modName = Meta.parse("mydata_" * pets[1])
+    #   #m = :modName
+    #   @eval import .$modName
 
-  # stuff the results into new objects of style e.g. data.mypet.etc, auxData.mypet.etc
-  # TO DO - simplify this!
-  petnm = Symbol(pets[i])
-  eval(:($petnm = data))
-  @eval begin
-    struct data_struct2
-      $petnm
+    # @eval import .$m
+    #   eval(Symbol(funcname))()
+    #   #@get_mydata_pets(pets[i])
+    # end  
+
+    i = 0
+    for file_name in ["c:/git/DEBtool_J.jl/example/mydata_" * x * ".jl" for x in pets]
+        i = i + 1
+        include(file_name) # load the mydata file
+
+        # stuff the results into new objects of style e.g. data.mypet.etc, auxData.mypet.etc
+        # TO DO - simplify this!
+        petnm = Symbol(pets[i])
+        eval(:($petnm = data))
+        @eval begin
+            struct data_struct2
+                $petnm
+            end
+            data = data_struct2($petnm)
+        end
+        eval(:($petnm = auxData))
+        @eval begin
+            struct auxData_struct2
+                $petnm
+            end
+            auxData = auxData_struct2($petnm)
+        end
+        eval(:($petnm = metaData))
+        @eval begin
+            struct metaData_struct2
+                $petnm
+            end
+            metaData = metaData_struct2($petnm)
+        end
+        eval(:($petnm = txtData))
+        @eval begin
+            struct txtData_struct2
+                $petnm
+            end
+            txtData = txtData_struct2($petnm)
+        end
+        eval(:($petnm = weights))
+        @eval begin
+            struct weights_struct2
+                $petnm
+            end
+            weights = weights_struct2($petnm)
+        end
     end
-    data = data_struct2($petnm)
-  end
-  eval(:($petnm = auxData))
-  @eval begin
-    struct auxData_struct2
-      $petnm
-    end
-    auxData = auxData_struct2($petnm)
-  end
-  eval(:($petnm=metaData))
-  @eval begin
-    struct metaData_struct2
-      $petnm
-    end
-    metaData = metaData_struct2($petnm)
-  end
-  eval(:($petnm=txtData))
-  @eval begin
-    struct txtData_struct2
-      $petnm
-    end
-    txtData = txtData_struct2($petnm)
-  end
-  eval(:($petnm=weights))
-  @eval begin
-    struct weights_struct2
-      $petnm
-    end
-    weights = weights_struct2($petnm)
-  end
-end
 
-#[data.(pets{i}), auxData.(pets{i}), metaData.(pets{i}), txtData.(pets{i}), weights.(pets{i})] = feval(['mydata_', pets{i}]);
-  # TO DO
-  # if pseudodata_pets == 1 # same pseudodata for the group
-  #   # remove pseudodata from species structure
-  #   data = rmpseudodata(data);
-  #   txtData = rmpseudodata(txtData); 
-  #   weights = rmpseudodata(weights);
+    #[data.(pets{i}), auxData.(pets{i}), metaData.(pets{i}), txtData.(pets{i}), weights.(pets{i})] = feval(['mydata_', pets{i}]);
+    # TO DO
+    # if pseudodata_pets == 1 # same pseudodata for the group
+    #   # remove pseudodata from species structure
+    #   data = rmpseudodata(data);
+    #   txtData = rmpseudodata(txtData); 
+    #   weights = rmpseudodata(weights);
 
-  #   # set pseudodata and respective weights for the group
-  #   if exist('addpseudodata_group.m', 'file')
-  #     [dataG, unitsG, labelG, weightsG] = addpseudodata_group;
-  #   else
-  #     [dataG, unitsG, labelG, weightsG] = addpseudodata([], [], [], []);
-  #     fprintf('No addpseudodata_group.m found, only default pseudodata and weights are considered for the group \n')      
-  #   end
-    
-  #   data.psd = dataG.psd;
-  #   weights.psd = weightsG.psd;
-  #   txtData.psd.units = unitsG.psd;
-  #   txtData.psd.label = labelG.psd;
-  return(data, auxData, metaData, txtData, weights)
+    #   # set pseudodata and respective weights for the group
+    #   if exist('addpseudodata_group.m', 'file')
+    #     [dataG, unitsG, labelG, weightsG] = addpseudodata_group;
+    #   else
+    #     [dataG, unitsG, labelG, weightsG] = addpseudodata([], [], [], []);
+    #     fprintf('No addpseudodata_group.m found, only default pseudodata and weights are considered for the group \n')      
+    #   end
+
+    #   data.psd = dataG.psd;
+    #   weights.psd = weightsG.psd;
+    #   txtData.psd.units = unitsG.psd;
+    #   txtData.psd.label = labelG.psd;
+    return (data, auxData, metaData, txtData, weights)
 end

--- a/src/lib/pet/parGrp2Pets.jl
+++ b/src/lib/pet/parGrp2Pets.jl
@@ -3,93 +3,91 @@
 
 ##
 function parGrp2Pets(parGrp)
-# created 2018/05/23 by Bas Kooijman
+    # created 2018/05/23 by Bas Kooijman
 
-## Syntax
-# parPets = <../parGrp2Pets.m *parGrp2Pets*> (parGrp)
+    ## Syntax
+    # parPets = <../parGrp2Pets.m *parGrp2Pets*> (parGrp)
 
-## Description
-# Converts parameter-structure for a group of pets to a structure of parameters for each pet. 
-# First-level field names of output-structure are the pets.
-# parPets.my_pet is the single-species parameter specification for my_pet, where all parameters are scalar
-#
-# Input:
-#
-# * parGrp: stucture with parameters for the group of pets (as in pars_init_group) that can be either scalar or vector-valued of length n_pets
-#
-# Output: 
-#
-# * parPets: structure with structures of parameters for each pet that are all scalar
+    ## Description
+    # Converts parameter-structure for a group of pets to a structure of parameters for each pet. 
+    # First-level field names of output-structure are the pets.
+    # parPets.my_pet is the single-species parameter specification for my_pet, where all parameters are scalar
+    #
+    # Input:
+    #
+    # * parGrp: stucture with parameters for the group of pets (as in pars_init_group) that can be either scalar or vector-valued of length n_pets
+    #
+    # Output: 
+    #
+    # * parPets: structure with structures of parameters for each pet that are all scalar
 
-## Remarks
-# In the case of no covariation rule, this function only copies group-specifications to single-species specifications.
-# In other cases, however, the total number of parameters can be further reduced by assuming relationships between parameters for different species.
-# Function <parPets2Grp.html *parPets2Grp*> maps from structure of parameters for each pet to that of a group
+    ## Remarks
+    # In the case of no covariation rule, this function only copies group-specifications to single-species specifications.
+    # In other cases, however, the total number of parameters can be further reduced by assuming relationships between parameters for different species.
+    # Function <parPets2Grp.html *parPets2Grp*> maps from structure of parameters for each pet to that of a group
 
-## Example of use
-# parPets = parGrp2Pets(parGrp)
+    ## Example of use
+    # parPets = parGrp2Pets(parGrp)
 
-  #global pets covRules(pets, par)
-  global parGrp2 = parGrp
-  n_pets = length(pets);
-  if n_pets == 1
-    #parPets.(pets{1}) = parGrp;
-    var_name = Symbol(pets[1])
-    @eval begin
-        global $var_name = parGrp2
-        struct parPets_struct
-            $var_name
+    #global pets covRules(pets, par)
+    global parGrp2 = parGrp
+    n_pets = length(pets)
+    if n_pets == 1
+        #parPets.(pets{1}) = parGrp;
+        var_name = Symbol(pets[1])
+        @eval begin
+            global $var_name = parGrp2
+            struct parPets_struct
+                $var_name
+            end
+            parPets = parPets_struct($var_name)
         end
-        parPets = parPets_struct($var_name)
+        return (parPets)
     end
-    return (parPets)
-  end
-  
-  # TO DO
-#   parNms = fieldnames(parGrp); n_parNms = length(parNms);
-#   vec_zeros = zeros(n_pets,1); # for expansion of free settings
-    
-#   # map group-specification to single-species specification
-#   for i = 1:n_pets         # scan pets
-#     pari = parGrp;         # prepare parameters for pet i
-#     # parameter value setting (skipping free setting)
-#     for j = 1:n_parNms     # scan parameters for each pet
-#       if ~strcmp(parNms{j},'free') 
-#         val = parGrp.(parNms{j}); n_val = length(val); # determine length 1 or n_pets
-#         pari.(parNms{j}) =  val(min(n_val,i));         # select value i for pet i
-#       end
-#     end
-#     # free setting
-#     if exist('pari.free','var') # if called from groupregr_f, parGrp has no field 'free'
-#       freeNms = fieldnames(pari.free); n_freeNms = length(freeNms);
-#       for k = 1:n_freeNms
-#         # in the case of scalar setting, use free = 0 for all species other than the first one
-#         # the corresponding parameter can still change, since this function is called after each change in any parameter, before predictions are computed
-#         val = pari.free.(freeNms{k}) + vec_zeros; # make sure that element j is defined
-#         pari.free.(freeNms{k}) =  val(i);         # select value i for pet i 
-#       end
-#     end
-#     parPets.(pets{i}) = pari; # copy parameters for pet i to output
-#   end
 
-#   switch covRules # global cov_rules specifies the co-variation rules that should be applied
-  
-#     case 'no'
-#     # do nothing 
-  
-#     case 'maturities' # modify maturity levels according to zoom factor z, using pets{1} as reference
-#     # the free-setting and the initial values of these parameters for pets{2} till pets.{n_pets} are ignored with this covRule
-#     for i = 2:n_pets         # scan pets, using pets{1} as reference
-#       for j = 1:n_parNms     # scan parameters for each pet
-#         if strcmp(parNms{j},'E_H') # identify maturity levels
-#           parPets.(pets{i}).(parNms{j}) = parPets.(pets{1}).(parNms{j}) * parPets.(pets{i}).z^3/ parPets.(pets{1}).z^3; 
-#         end
-#       end
-#     end
-    
-#     case 'bla'
-#     # add here your user-defined co-variation rules (replacing 'bla'), using case 'maturities' as example
-#     # insert 'estim_options('cov_rules','bla');' in the run-file for the group to actually use them
+    # TO DO
+    #   parNms = fieldnames(parGrp); n_parNms = length(parNms);
+    #   vec_zeros = zeros(n_pets,1); # for expansion of free settings
+
+    #   # map group-specification to single-species specification
+    #   for i = 1:n_pets         # scan pets
+    #     pari = parGrp;         # prepare parameters for pet i
+    #     # parameter value setting (skipping free setting)
+    #     for j = 1:n_parNms     # scan parameters for each pet
+    #       if ~strcmp(parNms{j},'free') 
+    #         val = parGrp.(parNms{j}); n_val = length(val); # determine length 1 or n_pets
+    #         pari.(parNms{j}) =  val(min(n_val,i));         # select value i for pet i
+    #       end
+    #     end
+    #     # free setting
+    #     if exist('pari.free','var') # if called from groupregr_f, parGrp has no field 'free'
+    #       freeNms = fieldnames(pari.free); n_freeNms = length(freeNms);
+    #       for k = 1:n_freeNms
+    #         # in the case of scalar setting, use free = 0 for all species other than the first one
+    #         # the corresponding parameter can still change, since this function is called after each change in any parameter, before predictions are computed
+    #         val = pari.free.(freeNms{k}) + vec_zeros; # make sure that element j is defined
+    #         pari.free.(freeNms{k}) =  val(i);         # select value i for pet i 
+    #       end
+    #     end
+    #     parPets.(pets{i}) = pari; # copy parameters for pet i to output
+    #   end
+
+    #   switch covRules # global cov_rules specifies the co-variation rules that should be applied
+
+    #     case 'no'
+    #     # do nothing 
+
+    #     case 'maturities' # modify maturity levels according to zoom factor z, using pets{1} as reference
+    #     # the free-setting and the initial values of these parameters for pets{2} till pets.{n_pets} are ignored with this covRule
+    #     for i = 2:n_pets         # scan pets, using pets{1} as reference
+    #       for j = 1:n_parNms     # scan parameters for each pet
+    #         if strcmp(parNms{j},'E_H') # identify maturity levels
+    #           parPets.(pets{i}).(parNms{j}) = parPets.(pets{1}).(parNms{j}) * parPets.(pets{i}).z^3/ parPets.(pets{1}).z^3; 
+    #         end
+    #       end
+    #     end
+
+    #     case 'bla'
+    #     # add here your user-defined co-variation rules (replacing 'bla'), using case 'maturities' as example
+    #     # insert 'estim_options('cov_rules','bla');' in the run-file for the group to actually use them
 end
-
-  

--- a/src/lib/pet/parscomp_st.jl
+++ b/src/lib/pet/parscomp_st.jl
@@ -3,10 +3,10 @@ function parscomp_st(p)
     # modified 2015/04/25 Starrlight, Bas Kooijman (kap_X_P replaced by kap_P)
     # modified 2015/08/03 by Starrlight, 2017/11/16, 2018/08/22 by Bas Kooijman, 
     # mod 2019/08/30 by Nina Marn (note on {p_Am})
-    
+
     ## Syntax
     # cPar = <../parscomp_st.m *parscomp_st*> (par, chem)
-    
+
     ## Description
     # Computes compound parameters from primary parameters that are frequently used
     #
@@ -17,7 +17,7 @@ function parscomp_st(p)
     # Output
     #
     # * cPar : structure with scaled quantities and compound parameters
-    
+
     ## Remarks
     # The quantities that are computed concern, where relevant:
     #
@@ -56,152 +56,163 @@ function parscomp_st(p)
     # * K: c-mol X/l, half-saturation coefficient
     # * M_H*, U_H*, V_H*, v_H*, u_H*: scaled maturities computed from all unscaled ones: E_H*
     # * s_H: -, maturity ratio E_Hb/ E_Hp
-   if !hasproperty(p,:p_Am)
-    p_Am = p.z * p.p_M/ p.kap * 1u"cm";   # J/d.cm^2, {p_Am} spec assimilation flux; the expression for p_Am is multiplied also by L_m^ref = 1 cm, for units to match. 
-   else
-    p_Am = p.p_Am;
-   end
-   global cPar = (;p_Am)
+    if !hasproperty(p, :p_Am)
+        p_Am = p.z * p.p_M / p.kap * 1u"cm"   # J/d.cm^2, {p_Am} spec assimilation flux; the expression for p_Am is multiplied also by L_m^ref = 1 cm, for units to match. 
+    else
+        p_Am = p.p_Am
+    end
+    global cPar = (; p_Am)
 
-   #         X       V       E       P
-   n_O = [p.n_CX p.n_CV p.n_CE p.n_CP  # C/C, equals 1 by definition
-          p.n_HX p.n_HV p.n_HE p.n_HP  # H/C  these values show that we consider dry-mass
-          p.n_OX p.n_OV p.n_OE p.n_OP  # O/C
-          p.n_NX p.n_NV p.n_NE p.n_NP]Unitful.mol/Unitful.mol; # N/C
-   #          C       H       O       N
-   n_M = [ p.n_CC p.n_CH p.n_CO p.n_CN  # CO2
-           p.n_HC p.n_HH p.n_HO p.n_HN  # H2O  
-           p.n_OC p.n_OH p.n_OO p.n_ON  # O2
-           p.n_NC p.n_NH p.n_NO p.n_NN]Unitful.mol/Unitful.mol; # NH3
-   cPar = merge(cPar, (;n_O, n_M))
-          
-  # -------------------------------------------------------------------------
-  # Molecular weights:
-  w_O = n_O' * [12, 1, 16, 14]Unitful.g/Unitful.mol; # g/mol, mol-weights for (unhydrated)  org. compounds
-  w_X = w_O[1];
-  w_V = w_O[2];
-  w_E = w_O[3];
-  w_P = w_O[4];
-  cPar = merge(cPar, (;w_X, w_V, w_E, w_P))
+    #         X       V       E       P
+    n_O =
+        [
+            p.n_CX p.n_CV p.n_CE p.n_CP  # C/C, equals 1 by definition
+            p.n_HX p.n_HV p.n_HE p.n_HP  # H/C  these values show that we consider dry-mass
+            p.n_OX p.n_OV p.n_OE p.n_OP  # O/C
+            p.n_NX p.n_NV p.n_NE p.n_NP
+        ]Unitful.mol / Unitful.mol # N/C
+    #          C       H       O       N
+    n_M =
+        [
+            p.n_CC p.n_CH p.n_CO p.n_CN  # CO2
+            p.n_HC p.n_HH p.n_HO p.n_HN  # H2O  
+            p.n_OC p.n_OH p.n_OO p.n_ON  # O2
+            p.n_NC p.n_NH p.n_NO p.n_NN
+        ]Unitful.mol / Unitful.mol # NH3
+    cPar = merge(cPar, (; n_O, n_M))
 
-  # -------------------------------------------------------------------------
-  # Conversions and compound parameters cPar
-  M_V     = p.d_V/ w_V;            # mol/cm^3, [M_V], volume-specific mass of structure
-  y_V_E   = p.mu_E * M_V/ p.E_G;     # mol/mol, yield of structure on reserve
-  y_E_V   = 1/ y_V_E;            # mol/mol, yield of reserve on structure
-  k_M     = p.p_M/ p.E_G;            # 1/d, somatic maintenance rate coefficient
-  k       = p.k_J/ k_M;            # -, maintenance ratio
-  E_m     = p_Am/ p.v;             # J/cm^3, [E_m], reserve capacity 
-  m_Em    = y_E_V * E_m / p.E_G;   # mol/mol, reserve capacity
-  g2       = p.E_G/ p.kap/ E_m ;      # -, energy investment ratio
-  L_m     = p.v/ k_M/ g2;           # cm, maximum length
-  L_T     = p.p_T/ p.p_M ;           # cm, heating length (also applies to osmotic work)
-  l_T     = L_T/ L_m;            # - , scaled heating length
-  ome     = m_Em * w_E * p.d_V/ p.d_E/ w_V; # -, \omega, contribution of ash free dry mass of reserve to total ash free dry biomass
-  w       = ome;                   # -, just for consistency with the past
-  J_E_Am  = p_Am/ p.mu_E;          # mol/d.cm^2, {J_EAm}, max surface-spec assimilation flux
-  
-  cPar = merge(cPar, (;M_V, y_V_E, y_E_V, k_M, k, E_m, m_Em, g=g2, L_m, L_T, l_T, ome, w, J_E_Am))
+    # -------------------------------------------------------------------------
+    # Molecular weights:
+    w_O = n_O' * [12, 1, 16, 14]Unitful.g / Unitful.mol # g/mol, mol-weights for (unhydrated)  org. compounds
+    w_X = w_O[1]
+    w_V = w_O[2]
+    w_E = w_O[3]
+    w_P = w_O[4]
+    cPar = merge(cPar, (; w_X, w_V, w_E, w_P))
 
-  if hasproperty(p,:E_Hp)
-    s_H = p.E_Hb/ p.E_Hp;        # -, maturity ratio
-  else
-    s_H = 1;
-  end
-  cPar = merge(cPar, (;s_H))
+    # -------------------------------------------------------------------------
+    # Conversions and compound parameters cPar
+    M_V = p.d_V / w_V            # mol/cm^3, [M_V], volume-specific mass of structure
+    y_V_E = p.mu_E * M_V / p.E_G     # mol/mol, yield of structure on reserve
+    y_E_V = 1 / y_V_E            # mol/mol, yield of reserve on structure
+    k_M = p.p_M / p.E_G            # 1/d, somatic maintenance rate coefficient
+    k = p.k_J / k_M            # -, maintenance ratio
+    E_m = p_Am / p.v             # J/cm^3, [E_m], reserve capacity 
+    m_Em = y_E_V * E_m / p.E_G   # mol/mol, reserve capacity
+    g2 = p.E_G / p.kap / E_m      # -, energy investment ratio
+    L_m = p.v / k_M / g2           # cm, maximum length
+    L_T = p.p_T / p.p_M           # cm, heating length (also applies to osmotic work)
+    l_T = L_T / L_m            # - , scaled heating length
+    ome = m_Em * w_E * p.d_V / p.d_E / w_V # -, \omega, contribution of ash free dry mass of reserve to total ash free dry biomass
+    w = ome                   # -, just for consistency with the past
+    J_E_Am = p_Am / p.mu_E          # mol/d.cm^2, {J_EAm}, max surface-spec assimilation flux
 
-  if hasproperty(p,:kap_X)
-    y_E_X  = p.kap_X * p.mu_X/ p.mu_E;  # mol/mol, yield of reserve on food
-    y_X_E  = 1/ y_E_X;            # mol/mol, yield of food on reserve
-    p_Xm   = p_Am/ p.kap_X;         # J/d.cm^2, max spec feeding power
-    J_X_Am = y_X_E * J_E_Am;      # mol/d.cm^2, {J_XAm}, max surface-spec feeding flux
-    cPar = merge(cPar, (;y_E_X, y_X_E, p_Xm, J_X_Am))
-  end
-  
-  if hasproperty(p,:kap_P)
-    y_P_X  = p.kap_P * p.mu_X/ p.mu_P;  # mol/mol, yield of faeces on food 
-    y_X_P  = 1/ y_P_X;            # mol/mol, yield of food on faeces
-    cPar = merge(cPar, (;y_P_X, y_X_P))
-  end
-  
-  if hasproperty(p,:kap_X) && hasproperty(p, :kap_P)
-    y_P_E  = y_P_X/ y_E_X;          # mol/mol, yield of faeces on reserve
-    #  Mass-power couplers
-    eta_XA = y_X_E/ p.mu_E;          # mol/J, food-assim energy coupler
-    eta_PA = y_P_E/ p.mu_E;          # mol/J, faeces-assim energy coupler
-    eta_VG = y_V_E/ p.mu_E;          # mol/J, struct-growth energy coupler
-    eta_O  = [  -eta_XA   0         0         # mol/J, mass-energy coupler
-                      0   0         eta_VG    # used in: J_O = eta_O * p
-                 1/p.mu_E   -1/p.mu_E   -1/p.mu_E
-                 eta_PA   0         0];
-    cPar = merge(cPar, (;y_P_E, eta_XA, eta_PA, eta_VG, eta_O))
-  end
-  
-  J_E_M   = p.p_M/ p.mu_E;          # mol/d.cm^3, [J_EM], volume-spec somatic  maint costs
-  J_E_T   = p.p_T/ p.mu_E;          # mol/d.cm^2, {J_ET}, surface-spec somatic  maint costs
-  j_E_M   = k_M * y_E_V;            # mol/d.mol, mass-spec somatic  maint costs
-  j_E_J   = p.k_J * y_E_V;          # mol/d.mol, mass-spec maturity maint costs
-  kap_G   = p.mu_V * M_V/ p.E_G;    # -, growth efficiency
-  E_V     = p.d_V * p.mu_V/ w_V;    # J/cm^3, [E_V] volume-specific energy of structure
-  cPar = merge(cPar, (;J_E_M, J_E_T, j_E_M, j_E_J, kap_G, E_V))
+    cPar = merge(
+        cPar,
+        (; M_V, y_V_E, y_E_V, k_M, k, E_m, m_Em, g = g2, L_m, L_T, l_T, ome, w, J_E_Am),
+    )
 
-  if hasproperty(p,:F_m)
-    K2 = J_X_Am/ p.F_m;        # c-mol X/l, half-saturation coefficient
-    cPar = merge(cPar, (;K=K2))
-  end
-  
-  if hasproperty(p,:E_Rj)
-    v_Rj = p.kap/ (1 - p.kap) * p.E_Rj/ p.E_G;
-    cPar = merge(cPar, (;v_Rj))
-  end
-  
-  # add the Scaled maturity maturity levels:
-   parNames = string.(fieldnames(typeof(p)));
-   matLev = parNames[findall(x->x=="E_H", first.(parNames, 3))];
-   matInd = replace.(matLev, "E_H" => "");
+    if hasproperty(p, :E_Hp)
+        s_H = p.E_Hb / p.E_Hp        # -, maturity ratio
+    else
+        s_H = 1
+    end
+    cPar = merge(cPar, (; s_H))
 
-  for i = 1:length(matInd)
-    stri = matInd[i];
-    
-    M_Hx = getproperty(p, Symbol("E_H" * stri))/ p.mu_E
-    symbol_name = Symbol("M_H", stri)
-    eval(:($symbol_name=$M_Hx))
-    eval(Meta.parse("cPar = merge(cPar, (;$(Symbol("M_H$stri"))))"))
+    if hasproperty(p, :kap_X)
+        y_E_X = p.kap_X * p.mu_X / p.mu_E  # mol/mol, yield of reserve on food
+        y_X_E = 1 / y_E_X            # mol/mol, yield of food on reserve
+        p_Xm = p_Am / p.kap_X         # J/d.cm^2, max spec feeding power
+        J_X_Am = y_X_E * J_E_Am      # mol/d.cm^2, {J_XAm}, max surface-spec feeding flux
+        cPar = merge(cPar, (; y_E_X, y_X_E, p_Xm, J_X_Am))
+    end
 
-    U_Hx = getproperty(p, Symbol("E_H" * stri))/ p_Am
-    symbol_name = Symbol("U_H", stri)
-    eval(:($symbol_name=$U_Hx))
-    eval(Meta.parse("cPar = merge(cPar, (;$(Symbol("U_H$stri"))))"))
+    if hasproperty(p, :kap_P)
+        y_P_X = p.kap_P * p.mu_X / p.mu_P  # mol/mol, yield of faeces on food 
+        y_X_P = 1 / y_P_X            # mol/mol, yield of food on faeces
+        cPar = merge(cPar, (; y_P_X, y_X_P))
+    end
 
-    V_Hx = getproperty(cPar, Symbol("U_H" * stri))/ (1 - p.kap)
-    symbol_name = Symbol("V_H", stri)
-    eval(:($symbol_name=$V_Hx))
-    eval(Meta.parse("cPar = merge(cPar, (;$(Symbol("V_H$stri"))))"))
+    if hasproperty(p, :kap_X) && hasproperty(p, :kap_P)
+        y_P_E = y_P_X / y_E_X          # mol/mol, yield of faeces on reserve
+        #  Mass-power couplers
+        eta_XA = y_X_E / p.mu_E          # mol/J, food-assim energy coupler
+        eta_PA = y_P_E / p.mu_E          # mol/J, faeces-assim energy coupler
+        eta_VG = y_V_E / p.mu_E          # mol/J, struct-growth energy coupler
+        eta_O = [
+            -eta_XA 0 0         # mol/J, mass-energy coupler
+            0 0 eta_VG    # used in: J_O = eta_O * p
+            1/p.mu_E -1/p.mu_E -1/p.mu_E
+            eta_PA 0 0
+        ]
+        cPar = merge(cPar, (; y_P_E, eta_XA, eta_PA, eta_VG, eta_O))
+    end
 
-    v_Hx = getproperty(cPar, Symbol("V_H" * stri)) * g2^2 * k_M^3/ p.v^2
-    symbol_name = Symbol("v_H", stri)
-    eval(:($symbol_name=$v_Hx))
-    eval(Meta.parse("cPar = merge(cPar, (;$(Symbol("v_H$stri"))))"))
+    J_E_M = p.p_M / p.mu_E          # mol/d.cm^3, [J_EM], volume-spec somatic  maint costs
+    J_E_T = p.p_T / p.mu_E          # mol/d.cm^2, {J_ET}, surface-spec somatic  maint costs
+    j_E_M = k_M * y_E_V            # mol/d.mol, mass-spec somatic  maint costs
+    j_E_J = p.k_J * y_E_V          # mol/d.mol, mass-spec maturity maint costs
+    kap_G = p.mu_V * M_V / p.E_G    # -, growth efficiency
+    E_V = p.d_V * p.mu_V / w_V    # J/cm^3, [E_V] volume-specific energy of structure
+    cPar = merge(cPar, (; J_E_M, J_E_T, j_E_M, j_E_J, kap_G, E_V))
 
-    u_Hx = getproperty(cPar, Symbol("U_H" * stri)) * g2^2 * k_M^3/ p.v^2
-    symbol_name = Symbol("u_H", stri)
-    eval(:($symbol_name=$u_Hx))
-    eval(Meta.parse("cPar = merge(cPar, (;$(Symbol("u_H$stri"))))"))
-    #cPar.(['M_H', stri]) = p.(['E_H', stri])/ p.mu_E;                 % mmol, maturity at level i
-    #cPar.(['U_H', stri]) = p.(['E_H', stri])/ p_Am;                   % cm^2 d, scaled maturity at level i
-    #cPar.(['V_H', stri]) = cPar.(['U_H', stri])/ (1 - p.kap);         % cm^2 d, scaled maturity at level i
-    #cPar.(['v_H', stri]) = cPar.(['V_H', stri]) * g^2 * k_M^3/ p.v^2; % -, scaled maturity density at level i
-    #cPar.(['u_H', stri]) = cPar.(['U_H', stri]) * g^2 * k_M^3/ p.v^2; % -, scaled maturity density at level i 
-  end          
+    if hasproperty(p, :F_m)
+        K2 = J_X_Am / p.F_m        # c-mol X/l, half-saturation coefficient
+        cPar = merge(cPar, (; K = K2))
+    end
 
-  # -------------------------------------------------------------------------
-  # pack output:
-  return(cPar)
-#=   return(p_Am=p_Am, w_X=w_X, w_V=w_V, w_E=w_E, w_P=w_P, M_V=M_V, y_V_E=y_V_E, y_E_V=y_E_V, 
-                k_M=k_M, k=k, E_m=E_m, m_Em=m_Em, g=g, L_m=L_m, L_T=L_T, l_T=l_T, ome=ome, w=w, s_H=s_H,
-                J_E_Am=J_E_Am, J_E_M=J_E_M, J_E_T=J_E_T, j_E_M=j_E_M, j_E_J=j_E_J, kap_G=kap_G, E_V=E_V, n_O=n_O, n_M=n_M,
-                M_Hb = M_Hb, U_Hb = U_Hb, V_Hb = V_Hb, v_Hb = v_Hb, u_Hb = u_Hb, M_Hp = M_Hp, U_Hp = U_Hp, V_Hp = V_Hp, v_Hp = v_Hp, u_Hp = u_Hp,
-                y_P_X = y_P_X, y_X_P = y_X_P, y_E_X = y_E_X, y_X_E = y_X_E, p_Xm = p_Xm, J_X_Am = J_X_Am, 
-                y_P_E = y_P_E, eta_XA = eta_XA, eta_PA = eta_PA, eta_VG = eta_VG, eta_O = eta_O, K = K) =#
-  # -------------------------------------------------------------------------
+    if hasproperty(p, :E_Rj)
+        v_Rj = p.kap / (1 - p.kap) * p.E_Rj / p.E_G
+        cPar = merge(cPar, (; v_Rj))
+    end
+
+    # add the Scaled maturity maturity levels:
+    parNames = string.(fieldnames(typeof(p)))
+    matLev = parNames[findall(x -> x == "E_H", first.(parNames, 3))]
+    matInd = replace.(matLev, "E_H" => "")
+
+    for i = 1:length(matInd)
+        stri = matInd[i]
+
+        M_Hx = getproperty(p, Symbol("E_H" * stri)) / p.mu_E
+        symbol_name = Symbol("M_H", stri)
+        eval(:($symbol_name = $M_Hx))
+        eval(Meta.parse("cPar = merge(cPar, (;$(Symbol("M_H$stri"))))"))
+
+        U_Hx = getproperty(p, Symbol("E_H" * stri)) / p_Am
+        symbol_name = Symbol("U_H", stri)
+        eval(:($symbol_name = $U_Hx))
+        eval(Meta.parse("cPar = merge(cPar, (;$(Symbol("U_H$stri"))))"))
+
+        V_Hx = getproperty(cPar, Symbol("U_H" * stri)) / (1 - p.kap)
+        symbol_name = Symbol("V_H", stri)
+        eval(:($symbol_name = $V_Hx))
+        eval(Meta.parse("cPar = merge(cPar, (;$(Symbol("V_H$stri"))))"))
+
+        v_Hx = getproperty(cPar, Symbol("V_H" * stri)) * g2^2 * k_M^3 / p.v^2
+        symbol_name = Symbol("v_H", stri)
+        eval(:($symbol_name = $v_Hx))
+        eval(Meta.parse("cPar = merge(cPar, (;$(Symbol("v_H$stri"))))"))
+
+        u_Hx = getproperty(cPar, Symbol("U_H" * stri)) * g2^2 * k_M^3 / p.v^2
+        symbol_name = Symbol("u_H", stri)
+        eval(:($symbol_name = $u_Hx))
+        eval(Meta.parse("cPar = merge(cPar, (;$(Symbol("u_H$stri"))))"))
+        #cPar.(['M_H', stri]) = p.(['E_H', stri])/ p.mu_E;                 % mmol, maturity at level i
+        #cPar.(['U_H', stri]) = p.(['E_H', stri])/ p_Am;                   % cm^2 d, scaled maturity at level i
+        #cPar.(['V_H', stri]) = cPar.(['U_H', stri])/ (1 - p.kap);         % cm^2 d, scaled maturity at level i
+        #cPar.(['v_H', stri]) = cPar.(['V_H', stri]) * g^2 * k_M^3/ p.v^2; % -, scaled maturity density at level i
+        #cPar.(['u_H', stri]) = cPar.(['U_H', stri]) * g^2 * k_M^3/ p.v^2; % -, scaled maturity density at level i 
+    end
+
+    # -------------------------------------------------------------------------
+    # pack output:
+    return (cPar)
+    #=   return(p_Am=p_Am, w_X=w_X, w_V=w_V, w_E=w_E, w_P=w_P, M_V=M_V, y_V_E=y_V_E, y_E_V=y_E_V, 
+                    k_M=k_M, k=k, E_m=E_m, m_Em=m_Em, g=g, L_m=L_m, L_T=L_T, l_T=l_T, ome=ome, w=w, s_H=s_H,
+                    J_E_Am=J_E_Am, J_E_M=J_E_M, J_E_T=J_E_T, j_E_M=j_E_M, j_E_J=j_E_J, kap_G=kap_G, E_V=E_V, n_O=n_O, n_M=n_M,
+                    M_Hb = M_Hb, U_Hb = U_Hb, V_Hb = V_Hb, v_Hb = v_Hb, u_Hb = u_Hb, M_Hp = M_Hp, U_Hp = U_Hp, V_Hp = V_Hp, v_Hp = v_Hp, u_Hp = u_Hp,
+                    y_P_X = y_P_X, y_X_P = y_X_P, y_E_X = y_E_X, y_X_E = y_X_E, p_Xm = p_Xm, J_X_Am = J_X_Am, 
+                    y_P_E = y_P_E, eta_XA = eta_XA, eta_PA = eta_PA, eta_VG = eta_VG, eta_O = eta_O, K = K) =#
+    # -------------------------------------------------------------------------
 end

--- a/src/lib/pet/petregr_f.jl
+++ b/src/lib/pet/petregr_f.jl
@@ -3,435 +3,468 @@
 
 ##
 function petregr_f(func, par, data, auxData, weights, filternm)
-# created 2001/09/07 by Bas Kooijman; 
-# modified 2015/01/29 by Goncalo Marques, 
-#   2015/03/21 by Bas Kooijman, 
-#   2015/03/30, 2015/04/27, 2015/07/29, 2016/05/05 by Goncalo Marques
-#   2018/05/23, 2019/12/20 by Bas Kooijman
+    # created 2001/09/07 by Bas Kooijman; 
+    # modified 2015/01/29 by Goncalo Marques, 
+    #   2015/03/21 by Bas Kooijman, 
+    #   2015/03/30, 2015/04/27, 2015/07/29, 2016/05/05 by Goncalo Marques
+    #   2018/05/23, 2019/12/20 by Bas Kooijman
 
-## Syntax
-# [q, info, itercount, fval] = <../petregr_f.m *petregr_f*> (func, par, data, auxData, weights, filternm)
+    ## Syntax
+    # [q, info, itercount, fval] = <../petregr_f.m *petregr_f*> (func, par, data, auxData, weights, filternm)
 
-## Description
-# Finds parameter values for a pet that minimizes the lossfunction using Nelder Mead's simplex method using a filter.
-# The filter gives always a pass in the case that no filter has been selected in <estim_options.html *estim_options*>.
-#
-# Input
-#
-# * func: character string with name of user-defined function;
-#      see nrregr_st or nrregr  
-# * par: structure with parameters
-# * data: structure with data
-# * auxData: structure with auxiliary data
-# * weights: structure with weights
-# * filternm: character string with name of user-defined filter function
-#  
-# Output
-# 
-# * q: structure with parameters, result that minimizes the loss function
-# * info: 1 if convergence has been successful; 0 otherwise
-# * itercount: nummber if iterations
-# * fval: minimum of loss function
+    ## Description
+    # Finds parameter values for a pet that minimizes the lossfunction using Nelder Mead's simplex method using a filter.
+    # The filter gives always a pass in the case that no filter has been selected in <estim_options.html *estim_options*>.
+    #
+    # Input
+    #
+    # * func: character string with name of user-defined function;
+    #      see nrregr_st or nrregr  
+    # * par: structure with parameters
+    # * data: structure with data
+    # * auxData: structure with auxiliary data
+    # * weights: structure with weights
+    # * filternm: character string with name of user-defined filter function
+    #  
+    # Output
+    # 
+    # * q: structure with parameters, result that minimizes the loss function
+    # * info: 1 if convergence has been successful; 0 otherwise
+    # * itercount: nummber if iterations
+    # * fval: minimum of loss function
 
-## Remarks
-# Set options with <nmregr_options.html *nmregr_options*>.
-# Similar to <nrregr_st.html *nrregr_st*>, but slower and a larger bassin of attraction and uses a filter.
-# The number of fields in data is variable.
-# See <groupregr_f.html *groupregr_f*> for the multi-species situation.
+    ## Remarks
+    # Set options with <nmregr_options.html *nmregr_options*>.
+    # Similar to <nrregr_st.html *nrregr_st*>, but slower and a larger bassin of attraction and uses a filter.
+    # The number of fields in data is variable.
+    # See <groupregr_f.html *groupregr_f*> for the multi-species situation.
 
-  global lossfunction, report, max_step_number, max_fun_evals, tol_simplex, tol_fun, simplex_size
-  global st, fieldsInCells, auxVar, Y, meanY, W, P, meanP, q, pets
-  # option settings
-  info = true; # initiate info setting
-  fileLossfunc = "lossfunction_" * lossfunction;
-  
-  # prepare variable
-  #   st: structure with dependent data values only
-  st = deepcopy(data);
-  nm, nst = fieldnmnst_st(st); # nst: number of data sets
+    global lossfunction, report, max_step_number, max_fun_evals, tol_simplex, tol_fun, simplex_size
+    global st, fieldsInCells, auxVar, Y, meanY, W, P, meanP, q, pets
+    # option settings
+    info = true # initiate info setting
+    fileLossfunc = "lossfunction_" * lossfunction
 
-  fieldsInCells = []
-  auxVar = []
-  for i = 1:nst   # makes st only with dependent variables
-    fieldsInCells = split(nm[i], ".")
-    #auxVar = getfield(st, fieldsInCells{1}{:});   # data in field nm{i}
-    fieldsInCells1 = join(fieldsInCells[1:end-1], ".")
-    auxVar = eval(Meta.parse("getfield(st.$fieldsInCells1, Symbol(fieldsInCells[end]))"))   # data in field nm[i]
-    if isa(auxVar, Vector) && length(auxVar) >=2
-    #[~, k, npage] = size(auxVar);
-    #if k>=2 && npage==1# columns 2,3,.. are treated as data to be predicted if npage==1
-      #st = setfield(st, fieldsInCells{1}{:}, auxVar(:,2:end));
-      eval(Meta.parse("setfield!(st.$fieldsInCells1, Symbol(fieldsInCells[end]), auxVar[2,:])"))
-    end
-  end
+    # prepare variable
+    #   st: structure with dependent data values only
+    st = deepcopy(data)
+    nm, nst = fieldnmnst_st(st) # nst: number of data sets
 
-  # Y: vector with all dependent data, NaNs omitted
-  # W: vector with all weights, but those that correspond NaNs in data omitted
-  YmeanY = struct2vector(st, nm, st);
-  Y = YmeanY[1] 
-  meanY = YmeanY[2]
-  W = struct2vector(weights, nm, st)[1]; 
-  
-  parnm = fieldnames(typeof(par.free));
-  np = Int(length(parnm));
-  #n_par = sum(cell2mat(struct2cell(par.free)));
-  n_par = 0
-  for field in parnm
-   n_par += Int(getproperty(par.free, field))
-  end
-
-  if n_par == 0
-    return; # no parameters to iterate
-  end
-  index = 1:np
-  index = index[vec([getfield(par.free, field) for field in fieldnames(typeof(par.free))]) .== 1]
-
-  free = deepcopy(par.free); # free is here removed, and after iteration added again
-  #q = rmfield(par, "free"); # copy input parameter matrix into output TO DO
-  q = deepcopy(par)
-  #qvec = cell2mat(struct2cell(q));
-  qvec = []
-  #i = 0
-  for field in fieldnames(typeof(par))
-    #i = i + 1
-    #field = fieldnames(typeof(par))[i]
-    if field != :free
-    aux = getproperty(par, field)
-    append!(qvec, aux...)
-    end
-  end
-  # set options if necessary
-  
-  if !@isdefined(max_step_number) || isempty(max_step_number)
-    nmregr_options("max_step_number", 200 * n_par);
-  end
-  if !@isdefined(max_fun_evals) || isempty(max_fun_evals)
-    nmregr_options("max_fun_evals", 200 * n_par);
-  end
-  if !@isdefined(tol_simplex) || isempty(tol_simplex)
-    nmregr_options("tol_simplex", 1e-4);
-  end
-  if !@isdefined(tol_fun) || isempty(tol_fun)
-    nmregr_options("tol_fun", 1e-4);
-  end
-  if !@isdefined(simplex_size) || isempty(simplex_size)
-    nmregr_options("simplex_size", 0.05);
-  end
-  if !@isdefined(report) || isempty(report)
-    nmregr_options("report", 1);
-  end
-
-  # Initialize parameters
-  rho = 1; chi = 2; psi = 0.5; sigma = 0.5;
-  onesn = Int.(ones(1, n_par));
-  two2np1 = 2:n_par + 1;
-  one2n = 1:n_par;
-  np1 = n_par + 1;
-
-  call_func = Meta.parse("$func(q, data, auxData, pets)")
-  call_fileLossfunc = Meta.parse("$fileLossfunc(Y, meanY, P, meanP, W)")
-  call_filternm = Meta.parse("$filternm(q)")
-  # Set up a simplex near the initial guess.
-  xin = qvec[index];    # Place input guess in the simplex
-  #v[:,1] = xin;
-  unit_xin = map(unit, xin)
-  v = zeros(Float64, length(xin), Int(n_par)+1).*unit_xin
-  v[:,1] = xin;
-  f = eval(call_func)[1];
-  PmeanP = struct2vector(f, nm, st);
-  P = PmeanP[1]
-  meanP = PmeanP[2]
-
-  fv = zeros(Float64, 1, Int(n_par)+1)
-  fv[:,1] .= eval(call_fileLossfunc);
-  #fv(:,1) = feval(fileLossfunc, Y, meanY, P, meanP, W);
-
-  # Following improvement suggested by L.Pfeffer at Stanford
-  usual_delta = simplex_size;         # 5 percent deltas is the default for non-zero terms
-  zero_term_delta = simplex_size/ 20; # Even smaller delta for zero elements of q
-  for j = 1:Int(n_par)
-    y = deepcopy(xin);
-    f_test = false;
-    step_reducer = 1; # step_reducer will serve to reduce usual_delta if the parameter set does not pass the filter
-    y_test = deepcopy(y);
-    while !f_test
-      if y[j] != 0
-        y_test[j] = (1 + usual_delta / step_reducer) * y[j];
-      else 
-        y_test[j] = zero_term_delta / step_reducer;
-      end
-      qvec[index] = y_test; 
-      #q = cell2struct(mat2cell(qvec, ones(np, 1), [1]), parnm);
-      q = NamedTuple{parnm}(Tuple(qvec))
-      #f_test = feval(filternm, q);
-      f_test, flag = eval(call_filternm)
-
-      if !f_test 
-        println("The parameter set for the simplex construction is not realistic. \n");
-        step_reducer = 2 * step_reducer;
-      else
-        #[f, f_test] = feval(func, q, data, auxData);
-        f, f_test = eval(call_func);
-
-        if !f_test 
-          println("The parameter set for the simplex construction is not realistic. \n");
-          step_reducer = 2 * step_reducer;
+    fieldsInCells = []
+    auxVar = []
+    for i = 1:nst   # makes st only with dependent variables
+        fieldsInCells = split(nm[i], ".")
+        #auxVar = getfield(st, fieldsInCells{1}{:});   # data in field nm{i}
+        fieldsInCells1 = join(fieldsInCells[1:end-1], ".")
+        auxVar =
+            eval(Meta.parse("getfield(st.$fieldsInCells1, Symbol(fieldsInCells[end]))"))   # data in field nm[i]
+        if isa(auxVar, Vector) && length(auxVar) >= 2
+            #[~, k, npage] = size(auxVar);
+            #if k>=2 && npage==1# columns 2,3,.. are treated as data to be predicted if npage==1
+            #st = setfield(st, fieldsInCells{1}{:}, auxVar(:,2:end));
+            eval(
+                Meta.parse(
+                    "setfield!(st.$fieldsInCells1, Symbol(fieldsInCells[end]), auxVar[2,:])",
+                ),
+            )
         end
-      end
-    end  
-    v[:,j+1] = y_test;
-    P, meanP = struct2vector(f, nm, st);
-    #fv(:,j+1) = feval(fileLossfunc, Y, meanY, P, meanP, W);
-    fv[:,j+1] .= eval(call_fileLossfunc);
-  end     
-
-  # sort so v(1,:) has the lowest function value 
-  #[fv,j] = sort(fv);
-  j, fv = sortperm(fv[1,:]), sort(fv[1,:])'
-  #v = v(:,j);
-  v = v[:, j]
-  how = "initial";
-  itercount = 1;
-  func_evals = n_par + 1;
-  if report == 1
-    println("step " * string(itercount) *  " ssq ", string(minimum(fv)) *  "-", string(maximum(fv)) *  " " *  how *  "\n");
-  end
-  info = true;
-
-  # Main algorithm
-  # Iterate until the diameter of the simplex is less than tol_simplex
-  #   AND the function values differ from the min by less than tol_fun,
-  #   or the max function evaluations are exceeded. (Cannot use OR instead of AND.)
-  while func_evals < max_fun_evals && itercount < max_step_number
-    #if maximum(Unitful.ustrip(abs.(v[:, two2np1] .- v[:, onesn]))) <= tol_simplex && maximum(Unitful.ustrip(abs.(fv[1].-fv[two2np1]))) <= tol_fun
-    if maximum(Unitful.ustrip(abs.(view(v, :, two2np1) .- view(v, :, onesn)))) <= tol_simplex && maximum(Unitful.ustrip(abs.(fv[1].-fv[two2np1]))) <= tol_fun
-        break
     end
-    how = "";
-   
-    # Compute the reflection point
-   
-    # xbar = average of the n (NOT n+1) best points
-    #xbar = sum(v(:,one2n), 2)/ n_par;
-    xbar = (sum(Unitful.ustrip(v[:, one2n]), dims=2) / n_par).*unit_xin
-    xr = (1 + rho) * xbar - rho * v[:,np1];
-    qvec[index] = xr; 
-    #q = cell2struct(mat2cell(qvec, ones(np, 1), [1]), parnm);
-    q = NamedTuple{parnm}(Tuple(qvec))
-    #f_test = feval(filternm, q);
-    f_test, flag = eval(call_filternm)
-    if !f_test
-      fxr = fv[:,np1] + 1;
-    else
-      #f, f_test = feval(func, q, data, auxData);
-      f, f_test = eval(call_func);
-      if !f_test 
-        fxr = fv[:,np1] + 1;
-      else
-        #[P, meanP] = struct2vector(f, nm, st);
-        P, meanP = struct2vector(f, nm, st);
-        #fxr = feval(fileLossfunc, Y, meanY, P, meanP, W);
-        fxr = eval(call_fileLossfunc);
-      end
+
+    # Y: vector with all dependent data, NaNs omitted
+    # W: vector with all weights, but those that correspond NaNs in data omitted
+    YmeanY = struct2vector(st, nm, st)
+    Y = YmeanY[1]
+    meanY = YmeanY[2]
+    W = struct2vector(weights, nm, st)[1]
+
+    parnm = fieldnames(typeof(par.free))
+    np = Int(length(parnm))
+    #n_par = sum(cell2mat(struct2cell(par.free)));
+    n_par = 0
+    for field in parnm
+        n_par += Int(getproperty(par.free, field))
     end
-    func_evals = func_evals + 1;
-   
-    if fxr < fv[1,1]#[1]
-      # Calculate the expansion point
-      xe = (1 + rho * chi) .* xbar - rho * chi .* v[:, np1];
-      qvec[index] = xe; 
-      q = NamedTuple{parnm}(Tuple(qvec))
-      #q = cell2struct(mat2cell(qvec, ones(np, 1), [1]), parnm);
-      f_test, flag = eval(call_filternm)
-      #f_test = feval(filternm, q);
-      if !f_test
-         fxe = fxr + 1;
-      else
-        #[f, f_test] = feval(func, q, data, auxData);
-        f, f_test = eval(call_func);
-        if !f_test 
-          fxe = fv[:,np1] + 1;
-        else
-          #[P, meanP] = struct2vector(f, nm, st);
-          #fxe = feval(fileLossfunc, Y, meanY, P, meanP, W);
-          P, meanP = struct2vector(f, nm, st);
-          fxe = eval(call_fileLossfunc);
+
+    if n_par == 0
+        return # no parameters to iterate
+    end
+    index = 1:np
+    index = index[vec([
+        getfield(par.free, field) for field in fieldnames(typeof(par.free))
+    ]).==1]
+
+    free = deepcopy(par.free) # free is here removed, and after iteration added again
+    #q = rmfield(par, "free"); # copy input parameter matrix into output TO DO
+    q = deepcopy(par)
+    #qvec = cell2mat(struct2cell(q));
+    qvec = []
+    #i = 0
+    for field in fieldnames(typeof(par))
+        #i = i + 1
+        #field = fieldnames(typeof(par))[i]
+        if field != :free
+            aux = getproperty(par, field)
+            append!(qvec, aux...)
         end
-      end
-      func_evals = func_evals + 1;
-      if fxe < fxr
-         v[:,np1] = xe;
-         fv[:,np1][1] = fxe;
-         how = "expand";
-      else
-         v[:,np1] = xr; 
-         fv[1,np1] = fxr;
-         how = "reflect";
-      end
-    else # fv(:,1) <= fxr
-      if fxr < fv[1,n_par]
-         v[:,np1] = xr; 
-         fv[1,np1] = fxr;
-         how = "reflect";
-      else # fxr >= fv(:,n_par) 
-         # Perform contraction
-         if fxr < fv[1,np1]
-            # Perform an outside contraction
-            xc = [1 + psi * rho] .* xbar - psi * rho .* v[:,np1];
-            #qvec(index) = xc; q = cell2struct(mat2cell(qvec, ones(np, 1), [1]), parnm);
-            qvec[index] = xc; 
+    end
+    # set options if necessary
+
+    if !@isdefined(max_step_number) || isempty(max_step_number)
+        nmregr_options("max_step_number", 200 * n_par)
+    end
+    if !@isdefined(max_fun_evals) || isempty(max_fun_evals)
+        nmregr_options("max_fun_evals", 200 * n_par)
+    end
+    if !@isdefined(tol_simplex) || isempty(tol_simplex)
+        nmregr_options("tol_simplex", 1e-4)
+    end
+    if !@isdefined(tol_fun) || isempty(tol_fun)
+        nmregr_options("tol_fun", 1e-4)
+    end
+    if !@isdefined(simplex_size) || isempty(simplex_size)
+        nmregr_options("simplex_size", 0.05)
+    end
+    if !@isdefined(report) || isempty(report)
+        nmregr_options("report", 1)
+    end
+
+    # Initialize parameters
+    rho = 1
+    chi = 2
+    psi = 0.5
+    sigma = 0.5
+    onesn = Int.(ones(1, n_par))
+    two2np1 = 2:n_par+1
+    one2n = 1:n_par
+    np1 = n_par + 1
+
+    call_func = Meta.parse("$func(q, data, auxData, pets)")
+    call_fileLossfunc = Meta.parse("$fileLossfunc(Y, meanY, P, meanP, W)")
+    call_filternm = Meta.parse("$filternm(q)")
+    # Set up a simplex near the initial guess.
+    xin = qvec[index]    # Place input guess in the simplex
+    #v[:,1] = xin;
+    unit_xin = map(unit, xin)
+    v = zeros(Float64, length(xin), Int(n_par) + 1) .* unit_xin
+    v[:, 1] = xin
+    f = eval(call_func)[1]
+    PmeanP = struct2vector(f, nm, st)
+    P = PmeanP[1]
+    meanP = PmeanP[2]
+
+    fv = zeros(Float64, 1, Int(n_par) + 1)
+    fv[:, 1] .= eval(call_fileLossfunc)
+    #fv(:,1) = feval(fileLossfunc, Y, meanY, P, meanP, W);
+
+    # Following improvement suggested by L.Pfeffer at Stanford
+    usual_delta = simplex_size         # 5 percent deltas is the default for non-zero terms
+    zero_term_delta = simplex_size / 20 # Even smaller delta for zero elements of q
+    for j = 1:Int(n_par)
+        y = deepcopy(xin)
+        f_test = false
+        step_reducer = 1 # step_reducer will serve to reduce usual_delta if the parameter set does not pass the filter
+        y_test = deepcopy(y)
+        while !f_test
+            if y[j] != 0
+                y_test[j] = (1 + usual_delta / step_reducer) * y[j]
+            else
+                y_test[j] = zero_term_delta / step_reducer
+            end
+            qvec[index] = y_test
+            #q = cell2struct(mat2cell(qvec, ones(np, 1), [1]), parnm);
             q = NamedTuple{parnm}(Tuple(qvec))
             #f_test = feval(filternm, q);
             f_test, flag = eval(call_filternm)
+
             if !f_test
-              fxc = fxr + 1;
-            else            
-              #[f, f_test] = feval(func, q, data, auxData);
-              f, f_test = eval(call_func);
-              if !f_test 
-                fxc = fv[:,np1] + 1;
-              else
-                #[P, meanP] = struct2vector(f, nm, st);
-                #fxc = feval(fileLossfunc, Y, meanY, P, meanP, W);
-                P, meanP = struct2vector(f, nm, st);
-                fxc = eval(call_fileLossfunc);
-              end
-            end
-            func_evals = func_evals + 1;
-            
-            if fxc <= fxr
-               v[:,np1] = xc; 
-               #fv[:,np1][1] = fxc;
-               fv[1,np1] = fxc;
-               how = "contract outside";
+                println(
+                    "The parameter set for the simplex construction is not realistic. \n",
+                )
+                step_reducer = 2 * step_reducer
             else
-               # perform a shrink
-               how = "shrink"; 
+                #[f, f_test] = feval(func, q, data, auxData);
+                f, f_test = eval(call_func)
+
+                if !f_test
+                    println(
+                        "The parameter set for the simplex construction is not realistic. \n",
+                    )
+                    step_reducer = 2 * step_reducer
+                end
             end
-         else
-            # Perform an inside contraction
-            xcc = (1 - psi) .* xbar + psi .* v[:,np1];
-            #qvec(index) = xcc; q = cell2struct(mat2cell(qvec, ones(np, 1), [1]), parnm);
-            qvec[index] = xcc; 
-            q = NamedTuple{parnm}(Tuple(qvec))
-            #f_test = feval(filternm, q);
-            f_test, flag = eval(call_filternm)
-            if !f_test
-              fxcc = fv[:,np1] + 1;
-            else
-              #[f, f_test] = feval(func, q, data, auxData);
-              f, f_test = eval(call_func);
-              if !f_test 
-                fxcc = fv[:,np1] + 1;
-              else
-                #[P, meanP] = struct2vector(f, nm, st);
-                #fxcc = feval(fileLossfunc, Y, meanY, P, meanP, W);
-                P, meanP = struct2vector(f, nm, st);
-                fxcc = eval(call_fileLossfunc);
-              end
-            end
-            func_evals = func_evals + 1;
-            
-            if fxcc < fv[1,np1]
-               v[:,np1] = xcc;
-               fv[1,np1] = fxcc;
-               how = "contract inside";
-            else
-               # perform a shrink
-               how = "shrink";
-            end
-         end
-         if how == "shrink"
-            for j = two2np1
-               f_test = false;
-               step_reducer = 1;             # step_reducer will serve to reduce usual_delta if the parameter set does not pass the filter
-               while !f_test
-                  v_test = v[:,1] + sigma / step_reducer * (v[:,j] - v[:,1]);
-                  #qvec(index) = v_test; q = cell2struct(mat2cell(qvec, ones(np, 1), [1]), parnm);
-                  #f_test = feval(filternm, q);
-                  qvec[index] = v_test; 
-                  q = NamedTuple{parnm}(Tuple(qvec))
-                  f_test, flag = eval(call_filternm)
-                  if !f_test 
-                     println("The parameter set for the simplex shrinking is not realistic. \n");
-                     step_reducer = 2 * step_reducer;
-                  else
-                    #[f, f_test] = feval(func, q, data, auxData);
-                    f, f_test = eval(call_func);
-                    if !f_test 
-                      println("The parameter set for the simplex shrinking is not realistic. \n");
-                      step_reducer = 2 * step_reducer;
-                    end
-                  end
-               end
-               v[:,j] = v_test;
-               #[P, meanP] = struct2vector(f, nm, st);
-               #fv(:,j) = feval(fileLossfunc, Y, meanY, P, meanP, W);
-               P, meanP = struct2vector(f, nm, st);
-               #fv(:,j+1) = feval(fileLossfunc, Y, meanY, P, meanP, W);
-               fv[:,j] .= eval(call_fileLossfunc);
-            end
-            func_evals = func_evals + n_par;
-         end
-      end
+        end
+        v[:, j+1] = y_test
+        P, meanP = struct2vector(f, nm, st)
+        #fv(:,j+1) = feval(fileLossfunc, Y, meanY, P, meanP, W);
+        fv[:, j+1] .= eval(call_fileLossfunc)
     end
+
+    # sort so v(1,:) has the lowest function value 
     #[fv,j] = sort(fv);
-    j, fv = sortperm(fv[1,:]), sort(fv[1,:])'
-    v = v[:,j];
-    itercount = itercount + 1;
-
-    if report == 1 && mod(itercount, 10) == 0
-      println("step " * string(itercount) *  " ssq ", string(minimum(fv)) *  "-", string(maximum(fv)) *  " " *  how *  "\n");
-    end  
-  end   # while
-
-
-  #qvec(index) = v(:,1); q = cell2struct(mat2cell(qvec, ones(np, 1), [1]), parnm);
-  qvec[index] = v[:,1]; 
-  q = NamedTuple{parnm}(Tuple(qvec))
-  #q.free = free; # add substructure free to q,
-  q = merge(q, (free = free,))
-
-  fval = minimum(fv); 
-  if func_evals >= max_fun_evals
-    if report > 0
-      println("No convergences with " *	string(max_fun_evals) * " function evaluations\n");
+    j, fv = sortperm(fv[1, :]), sort(fv[1, :])'
+    #v = v(:,j);
+    v = v[:, j]
+    how = "initial"
+    itercount = 1
+    func_evals = n_par + 1
+    if report == 1
+        println(
+            "step " * string(itercount) * " ssq ",
+            string(minimum(fv)) * "-",
+            string(maximum(fv)) * " " * how * "\n",
+        )
     end
-    info = false;
-  elseif itercount >= max_step_number 
-    if report > 0
-      println("No convergences with " * string(max_step_number) * " steps\n");
+    info = true
+
+    # Main algorithm
+    # Iterate until the diameter of the simplex is less than tol_simplex
+    #   AND the function values differ from the min by less than tol_fun,
+    #   or the max function evaluations are exceeded. (Cannot use OR instead of AND.)
+    while func_evals < max_fun_evals && itercount < max_step_number
+        #if maximum(Unitful.ustrip(abs.(v[:, two2np1] .- v[:, onesn]))) <= tol_simplex && maximum(Unitful.ustrip(abs.(fv[1].-fv[two2np1]))) <= tol_fun
+        if maximum(Unitful.ustrip(abs.(view(v, :, two2np1) .- view(v, :, onesn)))) <=
+           tol_simplex && maximum(Unitful.ustrip(abs.(fv[1] .- fv[two2np1]))) <= tol_fun
+            break
+        end
+        how = ""
+
+        # Compute the reflection point
+
+        # xbar = average of the n (NOT n+1) best points
+        #xbar = sum(v(:,one2n), 2)/ n_par;
+        xbar = (sum(Unitful.ustrip(v[:, one2n]), dims = 2) / n_par) .* unit_xin
+        xr = (1 + rho) * xbar - rho * v[:, np1]
+        qvec[index] = xr
+        #q = cell2struct(mat2cell(qvec, ones(np, 1), [1]), parnm);
+        q = NamedTuple{parnm}(Tuple(qvec))
+        #f_test = feval(filternm, q);
+        f_test, flag = eval(call_filternm)
+        if !f_test
+            fxr = fv[:, np1] + 1
+        else
+            #f, f_test = feval(func, q, data, auxData);
+            f, f_test = eval(call_func)
+            if !f_test
+                fxr = fv[:, np1] + 1
+            else
+                #[P, meanP] = struct2vector(f, nm, st);
+                P, meanP = struct2vector(f, nm, st)
+                #fxr = feval(fileLossfunc, Y, meanY, P, meanP, W);
+                fxr = eval(call_fileLossfunc)
+            end
+        end
+        func_evals = func_evals + 1
+
+        if fxr < fv[1, 1]#[1]
+            # Calculate the expansion point
+            xe = (1 + rho * chi) .* xbar - rho * chi .* v[:, np1]
+            qvec[index] = xe
+            q = NamedTuple{parnm}(Tuple(qvec))
+            #q = cell2struct(mat2cell(qvec, ones(np, 1), [1]), parnm);
+            f_test, flag = eval(call_filternm)
+            #f_test = feval(filternm, q);
+            if !f_test
+                fxe = fxr + 1
+            else
+                #[f, f_test] = feval(func, q, data, auxData);
+                f, f_test = eval(call_func)
+                if !f_test
+                    fxe = fv[:, np1] + 1
+                else
+                    #[P, meanP] = struct2vector(f, nm, st);
+                    #fxe = feval(fileLossfunc, Y, meanY, P, meanP, W);
+                    P, meanP = struct2vector(f, nm, st)
+                    fxe = eval(call_fileLossfunc)
+                end
+            end
+            func_evals = func_evals + 1
+            if fxe < fxr
+                v[:, np1] = xe
+                fv[:, np1][1] = fxe
+                how = "expand"
+            else
+                v[:, np1] = xr
+                fv[1, np1] = fxr
+                how = "reflect"
+            end
+        else # fv(:,1) <= fxr
+            if fxr < fv[1, n_par]
+                v[:, np1] = xr
+                fv[1, np1] = fxr
+                how = "reflect"
+            else # fxr >= fv(:,n_par) 
+                # Perform contraction
+                if fxr < fv[1, np1]
+                    # Perform an outside contraction
+                    xc = [1 + psi * rho] .* xbar - psi * rho .* v[:, np1]
+                    #qvec(index) = xc; q = cell2struct(mat2cell(qvec, ones(np, 1), [1]), parnm);
+                    qvec[index] = xc
+                    q = NamedTuple{parnm}(Tuple(qvec))
+                    #f_test = feval(filternm, q);
+                    f_test, flag = eval(call_filternm)
+                    if !f_test
+                        fxc = fxr + 1
+                    else
+                        #[f, f_test] = feval(func, q, data, auxData);
+                        f, f_test = eval(call_func)
+                        if !f_test
+                            fxc = fv[:, np1] + 1
+                        else
+                            #[P, meanP] = struct2vector(f, nm, st);
+                            #fxc = feval(fileLossfunc, Y, meanY, P, meanP, W);
+                            P, meanP = struct2vector(f, nm, st)
+                            fxc = eval(call_fileLossfunc)
+                        end
+                    end
+                    func_evals = func_evals + 1
+
+                    if fxc <= fxr
+                        v[:, np1] = xc
+                        #fv[:,np1][1] = fxc;
+                        fv[1, np1] = fxc
+                        how = "contract outside"
+                    else
+                        # perform a shrink
+                        how = "shrink"
+                    end
+                else
+                    # Perform an inside contraction
+                    xcc = (1 - psi) .* xbar + psi .* v[:, np1]
+                    #qvec(index) = xcc; q = cell2struct(mat2cell(qvec, ones(np, 1), [1]), parnm);
+                    qvec[index] = xcc
+                    q = NamedTuple{parnm}(Tuple(qvec))
+                    #f_test = feval(filternm, q);
+                    f_test, flag = eval(call_filternm)
+                    if !f_test
+                        fxcc = fv[:, np1] + 1
+                    else
+                        #[f, f_test] = feval(func, q, data, auxData);
+                        f, f_test = eval(call_func)
+                        if !f_test
+                            fxcc = fv[:, np1] + 1
+                        else
+                            #[P, meanP] = struct2vector(f, nm, st);
+                            #fxcc = feval(fileLossfunc, Y, meanY, P, meanP, W);
+                            P, meanP = struct2vector(f, nm, st)
+                            fxcc = eval(call_fileLossfunc)
+                        end
+                    end
+                    func_evals = func_evals + 1
+
+                    if fxcc < fv[1, np1]
+                        v[:, np1] = xcc
+                        fv[1, np1] = fxcc
+                        how = "contract inside"
+                    else
+                        # perform a shrink
+                        how = "shrink"
+                    end
+                end
+                if how == "shrink"
+                    for j in two2np1
+                        f_test = false
+                        step_reducer = 1             # step_reducer will serve to reduce usual_delta if the parameter set does not pass the filter
+                        while !f_test
+                            v_test = v[:, 1] + sigma / step_reducer * (v[:, j] - v[:, 1])
+                            #qvec(index) = v_test; q = cell2struct(mat2cell(qvec, ones(np, 1), [1]), parnm);
+                            #f_test = feval(filternm, q);
+                            qvec[index] = v_test
+                            q = NamedTuple{parnm}(Tuple(qvec))
+                            f_test, flag = eval(call_filternm)
+                            if !f_test
+                                println(
+                                    "The parameter set for the simplex shrinking is not realistic. \n",
+                                )
+                                step_reducer = 2 * step_reducer
+                            else
+                                #[f, f_test] = feval(func, q, data, auxData);
+                                f, f_test = eval(call_func)
+                                if !f_test
+                                    println(
+                                        "The parameter set for the simplex shrinking is not realistic. \n",
+                                    )
+                                    step_reducer = 2 * step_reducer
+                                end
+                            end
+                        end
+                        v[:, j] = v_test
+                        #[P, meanP] = struct2vector(f, nm, st);
+                        #fv(:,j) = feval(fileLossfunc, Y, meanY, P, meanP, W);
+                        P, meanP = struct2vector(f, nm, st)
+                        #fv(:,j+1) = feval(fileLossfunc, Y, meanY, P, meanP, W);
+                        fv[:, j] .= eval(call_fileLossfunc)
+                    end
+                    func_evals = func_evals + n_par
+                end
+            end
+        end
+        #[fv,j] = sort(fv);
+        j, fv = sortperm(fv[1, :]), sort(fv[1, :])'
+        v = v[:, j]
+        itercount = itercount + 1
+
+        if report == 1 && mod(itercount, 10) == 0
+            println(
+                "step " * string(itercount) * " ssq ",
+                string(minimum(fv)) * "-",
+                string(maximum(fv)) * " " * how * "\n",
+            )
+        end
+    end   # while
+
+
+    #qvec(index) = v(:,1); q = cell2struct(mat2cell(qvec, ones(np, 1), [1]), parnm);
+    qvec[index] = v[:, 1]
+    q = NamedTuple{parnm}(Tuple(qvec))
+    #q.free = free; # add substructure free to q,
+    q = merge(q, (free = free,))
+
+    fval = minimum(fv)
+    if func_evals >= max_fun_evals
+        if report > 0
+            println(
+                "No convergences with " * string(max_fun_evals) * " function evaluations\n",
+            )
+        end
+        info = false
+    elseif itercount >= max_step_number
+        if report > 0
+            println("No convergences with " * string(max_step_number) * " steps\n")
+        end
+        info = false
+    else
+        if report > 0
+            println("Successful convergence \n")
+        end
+        info = true
     end
-    info = false; 
-  else
-    if report > 0
-     println("Successful convergence \n");              
-    end
-    info = true;
-  end
-  (q, info, itercount, fval)
+    (q, info, itercount, fval)
 end
-   
+
 function struct2vector(structin, fieldNames, structRef)
-  # structRef has the same structure as struct, but some values can be NaN's; the values themselves are not used
-  # struct2vector is called for data (which might have NaN's), but also for predictions, which do not have NaN's
-  vec = Any[]
-  meanVec = Any[]
-  for i = 1:size(fieldNames, 1)
-    fieldsInCells = split(fieldNames[i], '.')
-    fieldsInCells1 = join(fieldsInCells[1:end-1], ".")
-    global structin2 = deepcopy(structin)
-    global fieldsInCells2 = deepcopy(fieldsInCells)
-    global structRef2 = deepcopy(structRef)
-    aux = eval(Meta.parse("getfield(structin2.$fieldsInCells1, Symbol(fieldsInCells2[end]))"))   # data in field nm[i]
-    auxRef = eval(Meta.parse("getfield(structRef2.$fieldsInCells1, Symbol(fieldsInCells2[end]))"))   # data in field nm[i]
-    #aux = aux[.!isnan.(auxRef)] # remove values that have NaN's in structRef - TO DO
-    if !isa(aux, AbstractArray)
-      aux = [aux]  # convert scalar to a 1-element array
+    # structRef has the same structure as struct, but some values can be NaN's; the values themselves are not used
+    # struct2vector is called for data (which might have NaN's), but also for predictions, which do not have NaN's
+    vec = Any[]
+    meanVec = Any[]
+    for i = 1:size(fieldNames, 1)
+        fieldsInCells = split(fieldNames[i], '.')
+        fieldsInCells1 = join(fieldsInCells[1:end-1], ".")
+        global structin2 = deepcopy(structin)
+        global fieldsInCells2 = deepcopy(fieldsInCells)
+        global structRef2 = deepcopy(structRef)
+        aux = eval(
+            Meta.parse("getfield(structin2.$fieldsInCells1, Symbol(fieldsInCells2[end]))"),
+        )   # data in field nm[i]
+        auxRef = eval(
+            Meta.parse("getfield(structRef2.$fieldsInCells1, Symbol(fieldsInCells2[end]))"),
+        )   # data in field nm[i]
+        #aux = aux[.!isnan.(auxRef)] # remove values that have NaN's in structRef - TO DO
+        if !isa(aux, AbstractArray)
+            aux = [aux]  # convert scalar to a 1-element array
+        end
+        append!(vec, aux...)
+        #append!(meanVec, fill(mean(aux), length(aux))...)
+        append!(meanVec, repeat(mean.(aux), length(aux[1]))...)
     end
-    append!(vec, aux...)
-    #append!(meanVec, fill(mean(aux), length(aux))...)
-    append!(meanVec, repeat(mean.(aux), length(aux[1]))...)
-  end
-  return (vec, meanVec)
+    return (vec, meanVec)
 end

--- a/src/lib/pet/predict_pets.jl
+++ b/src/lib/pet/predict_pets.jl
@@ -33,7 +33,8 @@ function predict_pets(parGrp, data, auxData, pets)
     for i = 1:n_pets
         petnm = pets[i]
         #[prdData.(pets{i}), info] = feval(["predict_", pets{i}], parPets.(pets{i}), data.(pets{i}), auxData.(pets{i}));
-        out = eval(Meta.parse("predict_$petnm(parPets.$petnm, data.$petnm, auxData.$petnm)"))
+        out =
+            eval(Meta.parse("predict_$petnm(parPets.$petnm, data.$petnm, auxData.$petnm)"))
         outData = out[1]
         info = out[2]
         petnm = pets[i]
@@ -44,10 +45,12 @@ function predict_pets(parGrp, data, auxData, pets)
         end
 
         # predict pseudodata
-        outPseudoData = eval(Meta.parse("predict_pseudodata(parPets.$petnm, data.$petnm, prdData.$petnm)"))
+        outPseudoData = eval(
+            Meta.parse("predict_pseudodata(parPets.$petnm, data.$petnm, prdData.$petnm)"),
+        )
         eval(Meta.parse("prdData = (;$petnm = outPseudoData)"))
 
         #prdData.(pets{i}) = predict_pseudodata(parPets.(pets{i}), data.(pets{i}), prdData.(pets{i}));
     end
-    return(;prdData, info)
+    return (; prdData, info)
 end

--- a/src/lib/pet/predict_pseudodata.jl
+++ b/src/lib/pet/predict_pseudodata.jl
@@ -3,59 +3,61 @@
 
 ##
 function predict_pseudodata(par, data, prdData)
-# created 2015/02/04 by Goncalo Marques
-# modified 2015/07/29
+    # created 2015/02/04 by Goncalo Marques
+    # modified 2015/07/29
 
-## Syntax
-# prd = <../predict_pseudodata.m *predict_pseudodata*> (par, data, prdData)
+    ## Syntax
+    # prd = <../predict_pseudodata.m *predict_pseudodata*> (par, data, prdData)
 
-## Description
-# Appends pseudodata predictions to a structure containing predictions for real data. 
-# Predictions generated using the par structure
-#
-# Inputs:
-#
-# * par : structure with parameters 
-# * data : structure with data
-# * prdData : structure with data predictions 
-#
-# Output: 
-#
-# * prdData : structure with predicted data and pseudodata 
+    ## Description
+    # Appends pseudodata predictions to a structure containing predictions for real data. 
+    # Predictions generated using the par structure
+    #
+    # Inputs:
+    #
+    # * par : structure with parameters 
+    # * data : structure with data
+    # * prdData : structure with data predictions 
+    #
+    # Output: 
+    #
+    # * prdData : structure with predicted data and pseudodata 
 
-## Example of use
-# prdData = predict_pseudodata(par, data, prdData)
+    ## Example of use
+    # prdData = predict_pseudodata(par, data, prdData)
 
-nm, nst = fieldnm_wtxt(data, "psd");
-if nst > 0
-  # unpack coefficients
-  cPar = parscomp_st(par);  #allPar = par;
-  #allPar = ntuple(i -> getfield(par, fieldnames(typeof(par))[i]), length(fieldnames(typeof(par))))
-  #allPar = NamedTuple{Tuple(fieldnames(typeof(par)))}(tuple(getfield(par, f) for f in fieldnames(typeof(par))))
-  npar = length(fieldnames(typeof(par)))
-  global allPar = NamedTuple{Tuple(map(Symbol, fieldnames(typeof(par)))[1:npar-1])}(getfield.(Ref(par), fieldnames(typeof(par))[1:npar-1]))
-  fieldNames = fieldnames(typeof(cPar));
-  for i = 1:length(fieldNames)
-    fldnm = fieldNames[i]
-    eval(Meta.parse("allPar = merge(allPar, ($fldnm = cPar.$fldnm,))"));
-  end
-  
-  fldnm = nm[1]
+    nm, nst = fieldnm_wtxt(data, "psd")
+    if nst > 0
+        # unpack coefficients
+        cPar = parscomp_st(par)  #allPar = par;
+        #allPar = ntuple(i -> getfield(par, fieldnames(typeof(par))[i]), length(fieldnames(typeof(par))))
+        #allPar = NamedTuple{Tuple(fieldnames(typeof(par)))}(tuple(getfield(par, f) for f in fieldnames(typeof(par))))
+        npar = length(fieldnames(typeof(par)))
+        global allPar = NamedTuple{Tuple(map(Symbol, fieldnames(typeof(par)))[1:npar-1])}(
+            getfield.(Ref(par), fieldnames(typeof(par))[1:npar-1]),
+        )
+        fieldNames = fieldnames(typeof(cPar))
+        for i = 1:length(fieldNames)
+            fldnm = fieldNames[i]
+            eval(Meta.parse("allPar = merge(allPar, ($fldnm = cPar.$fldnm,))"))
+        end
 
-  # TO DO - why does it need .Emydura_macquarii here?
-  varnm = eval(Meta.parse("fieldnames(typeof(data.Emydura_macquarii.$fldnm))")); 
+        fldnm = nm[1]
 
-  # adds pseudodata predictions to structure
-  for i = 1:length(varnm)
-    varnm2 = String(varnm[i])
-    if i == 1
-        eval(Meta.parse("psdtemp = ($varnm2 = allPar.$varnm2,)"));
-    else
-        eval(Meta.parse("psdtemp = merge(psdtemp, ($varnm2 = allPar.$varnm2,))"));
+        # TO DO - why does it need .Emydura_macquarii here?
+        varnm = eval(Meta.parse("fieldnames(typeof(data.Emydura_macquarii.$fldnm))"))
+
+        # adds pseudodata predictions to structure
+        for i = 1:length(varnm)
+            varnm2 = String(varnm[i])
+            if i == 1
+                eval(Meta.parse("psdtemp = ($varnm2 = allPar.$varnm2,)"))
+            else
+                eval(Meta.parse("psdtemp = merge(psdtemp, ($varnm2 = allPar.$varnm2,))"))
+            end
+            #prdData.psd.(varnm{i}) = allPar.(varnm{i});
+        end
+        prdData = merge(prdData, (psd = psdtemp,))
     end
-    #prdData.psd.(varnm{i}) = allPar.(varnm{i});
-  end
-  prdData = merge(prdData, (psd = psdtemp,))
-end
-return(prdData)
+    return (prdData)
 end

--- a/src/lib/pet/print_filterflag.jl
+++ b/src/lib/pet/print_filterflag.jl
@@ -2,49 +2,49 @@
 # prints an explanation of the filter flag onto the screen
 
 ##
-function  print_filterflag(flag)
-# created 2015/03/17 by Goncalo Marques; modified 2015/04/14 by Goncalo Marques
+function print_filterflag(flag)
+    # created 2015/03/17 by Goncalo Marques; modified 2015/04/14 by Goncalo Marques
 
-## Syntax
-# <../print_filterflag.m *print_filterflag*> (flag)
+    ## Syntax
+    # <../print_filterflag.m *print_filterflag*> (flag)
 
-## Description
-# Prints an explanation to the screen according to the flag produced by a
-#    filter
-# Meant to be run in the estimation procedure for the seed parameter set
-#
-# Input
-#
-# * flag: number with flag from filter
-#
-#      0: parameters pass the filter
-#      1: some parameter is negative
-#      2: some kappa or f is larger than 1
-#      3: growth efficiency is larger than 1
-#      4: maturity levels do not increase during life cycle
-#      5: puberty cannot be reached
+    ## Description
+    # Prints an explanation to the screen according to the flag produced by a
+    #    filter
+    # Meant to be run in the estimation procedure for the seed parameter set
+    #
+    # Input
+    #
+    # * flag: number with flag from filter
+    #
+    #      0: parameters pass the filter
+    #      1: some parameter is negative
+    #      2: some kappa or f is larger than 1
+    #      3: growth efficiency is larger than 1
+    #      4: maturity levels do not increase during life cycle
+    #      5: puberty cannot be reached
 
-## Remarks
-# The theory behind boundaries is discussed in <http://www.bio.vu.nl/thb/research/bib/LikaAugu2013.html *LikaAugu2013*>.
+    ## Remarks
+    # The theory behind boundaries is discussed in <http://www.bio.vu.nl/thb/research/bib/LikaAugu2013.html *LikaAugu2013*>.
 
 
-#switch flag
-  
+    #switch flag
+
     if flag == 1
-      println("One or more parameters are negative \n");
-      
+        println("One or more parameters are negative \n")
+
     elseif flag == 2
-      println("kappa, f or one of the fractions is bigger than 1 \n");
-      
+        println("kappa, f or one of the fractions is bigger than 1 \n")
+
     elseif flag == 3
-      println("growth efficiency is bigger than 1 \n");
-      
+        println("growth efficiency is bigger than 1 \n")
+
     elseif flag == 4
-      println("maturity levels are not in the correct order \n");
+        println("maturity levels are not in the correct order \n")
 
     elseif flag == 5
-      println("puberty or birth cannot be reached \n");
+        println("puberty or birth cannot be reached \n")
     end
-  
-#end
+
+    #end
 end

--- a/src/lib/pet/reach_birth.jl
+++ b/src/lib/pet/reach_birth.jl
@@ -3,47 +3,47 @@
 
 ##
 function reach_birth(g, k, v_Hb, f)
-# created 2015/06/19 by Goncalo Marques; modified 2015/07/06
-  
-## Syntax
-# info = <../reach_birth.m *reach_birth*>(g, k, v_Hb, f)
-  
-## Description
-# Checks if parameters allow for reaching birth in the standard DEB model
-#
-# Input
-#
-# * g: energy investment ratio
-# * k: ratio of maturity and somatic maintenance rate coeff
-# * v_Hb: scaled maturity volume at birth
-# * f: (opfional) functional response
-#  
-# Output
-#
-# * info: indicator equals 1 if reaches birth, 0 otherwise
-  
-  #if ~exist('f', 'var') # if f is not given it is taken as 1
-  if !@isdefined(f)
-    f = 1;
-  elseif isempty(f)
-    f = 1;
-  end  
-  
-  p = [g, k, v_Hb];
-  l_b, info = get_lb(p, f);
-  
-  if l_b >= f || ~info # constraint required for reaching birth
-    info = false; 
-    return(info)   
-    return;
-  end
-    
-  if k * v_Hb >= f/ (g + f) * l_b^2 * (g + l_b) # constraint required for reaching birth
-    info = false; 
-    return(info)   
-    return;
-  end
-  
-  info = true;
-  return(info)
+    # created 2015/06/19 by Goncalo Marques; modified 2015/07/06
+
+    ## Syntax
+    # info = <../reach_birth.m *reach_birth*>(g, k, v_Hb, f)
+
+    ## Description
+    # Checks if parameters allow for reaching birth in the standard DEB model
+    #
+    # Input
+    #
+    # * g: energy investment ratio
+    # * k: ratio of maturity and somatic maintenance rate coeff
+    # * v_Hb: scaled maturity volume at birth
+    # * f: (opfional) functional response
+    #  
+    # Output
+    #
+    # * info: indicator equals 1 if reaches birth, 0 otherwise
+
+    #if ~exist('f', 'var') # if f is not given it is taken as 1
+    if !@isdefined(f)
+        f = 1
+    elseif isempty(f)
+        f = 1
+    end
+
+    p = [g, k, v_Hb]
+    l_b, info = get_lb(p, f)
+
+    if l_b >= f || ~info # constraint required for reaching birth
+        info = false
+        return (info)
+        return
+    end
+
+    if k * v_Hb >= f / (g + f) * l_b^2 * (g + l_b) # constraint required for reaching birth
+        info = false
+        return (info)
+        return
+    end
+
+    info = true
+    return (info)
 end

--- a/src/lib/pet/setweights.jl
+++ b/src/lib/pet/setweights.jl
@@ -2,44 +2,44 @@
 # Sets automatically the weights for the data (to be used in a regression)  
 
 ##
-function setweights(data, weight) 
-# created 2015/01/16 by Goncalo Marques and Bas Kooijman; modified 2015/03/30, 2016/02/11, 2016/05/06 by Goncalo Marques
+function setweights(data, weight)
+    # created 2015/01/16 by Goncalo Marques and Bas Kooijman; modified 2015/03/30, 2016/02/11, 2016/05/06 by Goncalo Marques
 
-## Syntax
-# weight = <../setweights.m *setweights*> (data, weight)
+    ## Syntax
+    # weight = <../setweights.m *setweights*> (data, weight)
 
-## Description
-# computes weights for given data and adds it to the weight structure:
-# one divided by the number of data-points
-#
-# Inputs:
-#
-# * data : structure with data 
-# * weight : structure with weights
-#
-# Output: 
-#
-# * weight : structure with added weights from data 
+    ## Description
+    # computes weights for given data and adds it to the weight structure:
+    # one divided by the number of data-points
+    #
+    # Inputs:
+    #
+    # * data : structure with data 
+    # * weight : structure with weights
+    #
+    # Output: 
+    #
+    # * weight : structure with added weights from data 
 
-## Example of use
-# weight = setweights(data, [])
-# computes the data weights for all data and outputs a new structure weight with the results 
-# weight = setweights(data, weight)
-# computes the missing data weights in structure weight and adds them to it 
+    ## Example of use
+    # weight = setweights(data, [])
+    # computes the data weights for all data and outputs a new structure weight with the results 
+    # weight = setweights(data, weight)
+    # computes the missing data weights in structure weight and adds them to it 
 
-nm = fieldnames(typeof(data)); # vector of cells with names of data sets
-for i in 1:length(nm)
-  nvar = length(getproperty(data, nm[i]));
-  #if ~isfield(weight, nm[i]) 
-    if nvar == 1 # zero-variate data
-     setproperty!(weights, nm[i], 1)# weight.(nm[1]) = 1; 
-    elseif nvar==2 # uni- or bi-variate data
-       N = length(getproperty(data, nm[i])[1])  
-      setproperty!(weights, nm[i], ones(N, nvar-1)/ N/ (nvar-1));
-    else # tri-variate data
-      weight.(nm[i]) = ones(N, nvar, npage)/ N/ nvar/ npage;
+    nm = fieldnames(typeof(data)) # vector of cells with names of data sets
+    for i = 1:length(nm)
+        nvar = length(getproperty(data, nm[i]))
+        #if ~isfield(weight, nm[i]) 
+        if nvar == 1 # zero-variate data
+            setproperty!(weights, nm[i], 1)# weight.(nm[1]) = 1; 
+        elseif nvar == 2 # uni- or bi-variate data
+            N = length(getproperty(data, nm[i])[1])
+            setproperty!(weights, nm[i], ones(N, nvar - 1) / N / (nvar - 1))
+        else # tri-variate data
+            weight.(nm[i]) = ones(N, nvar, npage) / N / nvar / npage
+        end
+        #end
     end
-  #end
-end
-(weight)
+    (weight)
 end

--- a/src/lib/regr/fieldnmnst_st.jl
+++ b/src/lib/regr/fieldnmnst_st.jl
@@ -22,34 +22,33 @@ function fieldnmnst_st(st)
     #  x.reprod.dat
     #  the list of field names will be:
     #  nm = ["len.dat1", "len.dat2", "temp", "repod.dat"]
-    
+
     ## Code
-    nm = fieldnames(typeof(st));
-    nst = length(nm); # number of data sets
-    baux = 1;
+    nm = fieldnames(typeof(st))
+    nst = length(nm) # number of data sets
+    baux = 1
     while baux == 1
-      nmaux = [];
-      baux = 0;
-      for i = 1:nst
-        #eval(['isstruct(st.', nm{i}, ')'])
-        nmi = Symbol(nm[i])
-        if eval(Meta.parse("length(fieldnames(typeof(st.$nmi)))")) > 1#eval(['isstruct(st.', nm{i}, ')'])
-            eval(Meta.parse("vaux=fieldnames(typeof(st.$nmi))"))
-            #eval(["vaux = fieldnames(st.", nm{i}, ");"]);
-            nv = length(vaux);
-          for j = 1:nv
-            #nmaux = [nmaux; cellstr(strcat(nm{i}, ".", vaux{j}))];
-            push!(nmaux, string(nm[i], ".", vaux[j]))
-          end
-          baux = 1;
-        else
-          # nmaux = [nmaux; nm(i)];
-          push!(nmaux, nm[i])
+        nmaux = []
+        baux = 0
+        for i = 1:nst
+            #eval(['isstruct(st.', nm{i}, ')'])
+            nmi = Symbol(nm[i])
+            if eval(Meta.parse("length(fieldnames(typeof(st.$nmi)))")) > 1#eval(['isstruct(st.', nm{i}, ')'])
+                eval(Meta.parse("vaux=fieldnames(typeof(st.$nmi))"))
+                #eval(["vaux = fieldnames(st.", nm{i}, ");"]);
+                nv = length(vaux)
+                for j = 1:nv
+                    #nmaux = [nmaux; cellstr(strcat(nm{i}, ".", vaux{j}))];
+                    push!(nmaux, string(nm[i], ".", vaux[j]))
+                end
+                baux = 1
+            else
+                # nmaux = [nmaux; nm(i)];
+                push!(nmaux, nm[i])
+            end
         end
-      end
-      nm = deepcopy(nmaux);
-      nst = length(nm);
+        nm = deepcopy(nmaux)
+        nst = length(nm)
     end
-    return(nm, nst)
-end 
-  
+    return (nm, nst)
+end

--- a/src/lib/regr/lossfunction_sb.jl
+++ b/src/lib/regr/lossfunction_sb.jl
@@ -29,7 +29,9 @@ function lossfunction_sb(data, meanData, prdData, meanPrdData, weights)
 
 
     sel = .!isnan.(data)
-    lf = weights[sel]' * ((data[sel] .- prdData[sel]) .^ 2 ./ (meanData[sel] .^ 2 .+ meanPrdData[sel] .^ 2))
+    lf =
+        weights[sel]' *
+        ((data[sel] .- prdData[sel]) .^ 2 ./ (meanData[sel] .^ 2 .+ meanPrdData[sel] .^ 2))
 
     return (lf)
 end


### PR DESCRIPTION
This PR runs `JuliaFormatter.format` on all the source code, standardising indents, spacing etc 

It fails for `results_pet.jl` as it still seems to be MATLAB code. But everything else parses properly