### PR TITLE
use NamedTuples rather than structs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 ModelParameters = "4744a3fa-6c31-4707-899e-a3298e4618ad"
-OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"

--- a/example/mydata_Emydura_macquarii.jl
+++ b/example/mydata_Emydura_macquarii.jl
@@ -4,65 +4,43 @@
 # using Unitful
 # using Unitful: °C, K, d, g, cm, mol, J
 # using ..addpseudodata
-@with_kw mutable struct metaData_struct{T}
-    phylum::String = "Chordata"
-    class::String = "Reptilia"
-    order::String = "Testudines"
-    family::String = "Chelidae"
-    species::String = "Emydura_macquarii"
-    species_en::String = "Murray River turtle"
-    ecoCode::Any
-    T_typical::T = Unitful.K(22Unitful.°C)
-    data_0::Vector{String} =
-        ["ab_T", "ap", "am", "Lb", "Lp", "Li", "Wwb", "Wwp", "Wwi", "Ri"]
-    data_1::Vector{String} = ["t-L"]
-    COMPLETE::Float32 = 2.5
-    author::String = "Bas Kooijman"
-    date_subm::Vector{Int32} = [2017, 10, 09]
-    email::String = "bas.kooijman@vu.nl"
-    address::String = "VU University, Amsterdam"
-    curator::String = "Starrlight Augustine"
-    email_cur::String = "starrlight@akvaplan.niva.no"
-    date_acc::Vector{Int32} = [2017, 10, 09]
-    links::Any
-    facts::Any
-    discussion::Any
-    bibkey::Any
-    biblist::Any
-end
+metaData = (;
+    phylum = "Chordata",
+    class = "Reptilia",
+    order = "Testudines",
+    family = "Chelidae",
+    species = "Emydura_macquarii",
+    species_en = "Murray River turtle",
+    # ecoCode::Any,
+    T_typical = Unitful.K(22Unitful.°C),
+    data_0 = ["ab_T", "ap", "am", "Lb", "Lp", "Li", "Wwb", "Wwp", "Wwi", "Ri"],
+    data_1 = ["t-L"],
+    COMPLETE = 2.5,
+    author = "Bas Kooijman",
+    date_subm = [2017, 10, 09],
+    email = "bas.kooijman@vu.nl",
+    address = "VU University, Amsterdam",
+    curator = "Starrlight Augustine",
+    email_cur = "starrlight@akvaplan.niva.no",
+    date_acc = [2017, 10, 09],
+    # links
+    # facts
+    # discussion
+    # bibkey
+    # biblist
+)
 
-@with_kw mutable struct ecoCode_struct
-    climate::Vector{String} = ["Cfa", "Cfb"]
-    ecozone::Vector{String} = ["TA"]
-    habitat::Vector{String} = ["0bTd", "biFr"]
-    embryo::Vector{String} = ["Tt"]
-    migrate::Vector{String} = []
-    food::Vector{String} = ["biCi"]
-    gender::Vector{String} = ["Dg"]
-    reprod::Vector{String} = ["O"]
-end
-ecoCode = ecoCode_struct()
+ecoCode = (;
+    climate = ["Cfa", "Cfb"],
+    ecozone = ["TA"],
+    habitat = ["0bTd", "biFr"],
+    embryo = ["Tt"],
+    migrate = String[],
+    food = ["biCi"],
+    gender = ["Dg"],
+    reprod = ["O"],
+)
 
-@with_kw mutable struct data_struct{A,L,W,R}
-    ab::A = 78.0d
-    ab30::A = 48.0d
-    tp::A = 10.0 * 365.0d
-    tpm::A = 5.5 * 365.0d
-    am::A = 20.9 * 365.0d
-    Lb::L = 2.7cm
-    Lp::L = 18.7cm
-    Lpm::L = 14.7cm
-    Li::L = 21.4cm
-    Lim::L = 20.8cm
-    Wwb::W = 8.0g
-    Wwp::W = 2669.0g
-    Wwpm::W = 1297.0g
-    Wwi::W = 4000.0g
-    Wwim::W = 3673.0g
-    Ri::R = 36.0 / 365.0d
-    tL::Any
-    psd::Any
-end
 tL1 = [
     0.981 6.876
     0.981 7.090
@@ -89,184 +67,199 @@ tL1 = [
     3.883 12.953
     3.934 14.072
 ]
+
 tL_age = tL1[:, 1] * 365 * u"d"
 tL_length = tL1[:, 2] * u"cm"
 tL2 = [tL_age, tL_length]
-data = data_struct(tL = tL2, psd = psdData)
 
-@with_kw mutable struct temp_struct{T}
-    ab::T = Unitful.K(22Unitful.°C)
-    ab30::T = Unitful.K(30Unitful.°C)
-    tp::T = Unitful.K(22Unitful.°C)
-    tpm::T = Unitful.K(22Unitful.°C)
-    am::T = Unitful.K(22Unitful.°C)
-    ri::T = Unitful.K(22Unitful.°C)
-    tL::T = Unitful.K(22Unitful.°C)
-end
-temp = temp_struct()
+data = (;
+    ab = 78.0d,
+    ab30 = 48.0d,
+    tp = 10.0 * 365.0d,
+    tpm = 5.5 * 365.0d,
+    am = 20.9 * 365.0d,
+    Lb = 2.7cm,
+    Lp = 18.7cm,
+    Lpm = 14.7cm,
+    Li = 21.4cm,
+    Lim = 20.8cm,
+    Wwb = 8.0g,
+    Wwp = 2669.0g,
+    Wwpm = 1297.0g,
+    Wwi = 4000.0g,
+    Wwim = 3673.0g,
+    Ri = 36.0 / 365.0d,
+    tl = tL2 ,
+    psd = psdData,
+)
 
-@with_kw mutable struct label_struct
-    ab::String = "age at birth"
-    ab30::String = "age at birth"
-    tp::String = "time since birth at puberty for females"
-    tpm::String = "time since birth at puberty for males"
-    am::String = "life span"
-    Lb::String = "plastron length at birth"
-    Lp::String = "plastron length at puberty for females"
-    Lpm::String = "plastron length at puberty for males"
-    Li::String = "ultimate plastron length for females"
-    Lim::String = "ultimate plastron length for females"
-    Wwb::String = "wet weight at birth"
-    Wwp::String = "wet weight at puberty for females"
-    Wwpm::String = "wet weight at puberty for males"
-    Wwi::String = "ultimate wet weight for females"
-    Wwim::String = "ultimate wet weight for males"
-    Ri::String = "maximum reprod rate"
-    tL::Vector{String} = ["time since birth", "carapace length"]
-    psd::Any
-end
-label = label_struct(psd = psdLabel)
+temp = (;
+    abg = Unitful.K(22Unitful.°C),
+    ab30g = Unitful.K(30Unitful.°C),
+    tpg = Unitful.K(22Unitful.°C),
+    tpmg = Unitful.K(22Unitful.°C),
+    amg = Unitful.K(22Unitful.°C),
+    rig = Unitful.K(22Unitful.°C),
+    tLg = Unitful.K(22Unitful.°C),
+)
 
-@with_kw mutable struct bibkey_struct
-    ab::String = "carettochelys"
-    ab30::String = "carettochelys"
-    tp::String = "Spen2002"
-    tpm::String = "Spen2002"
-    am::String = "life span"
-    Lb::String = "Spen2002"
-    Lp::String = "Spen2002"
-    Lpm::String = "Spen2002"
-    Li::String = "Spen2002"
-    Lim::String = "Spen2002"
-    Wwb::String = "Spen2002"
-    Wwp::String = "Spen2002"
-    Wwpm::String = "Spen2002"
-    Wwi::String = "carettochelys"
-    Wwim::String = "carettochelys"
-    Ri::String = "Spen2002"
-    tL::String = "Spen2002"
-    F1::String = "Wiki"
-end
-bibkey = bibkey_struct()
+label = (;
+    ab = "age at birth",
+    ab30 = "age at birth",
+    tp = "time since birth at puberty for females",
+    tpm = "time since birth at puberty for males",
+    am = "life span",
+    Lb = "plastron length at birth",
+    Lp = "plastron length at puberty for females",
+    Lpm = "plastron length at puberty for males",
+    Li = "ultimate plastron length for females",
+    Lim = "ultimate plastron length for females",
+    Wwb = "wet weight at birth",
+    Wwp = "wet weight at puberty for females",
+    Wwpm = "wet weight at puberty for males",
+    Wwi = "ultimate wet weight for females",
+    Wwim = "ultimate wet weight for males",
+    Ri = "maximum reprod rate",
+    tL = ["time since birth", "carapace length"],
+    psd = psdLabel,
+)
 
-@with_kw mutable struct units_struct
-    ab::String = "d"
-    ab30::String = "d"
-    tp::String = "d"
-    tpm::String = "d"
-    am::String = "d"
-    Lb::String = "cm"
-    Lp::String = "cm"
-    Lpm::String = "cm"
-    Li::String = "cm"
-    Lim::String = "cm"
-    Wwb::String = "g"
-    Wwp::String = "g"
-    Wwpm::String = "g"
-    Wwi::String = "g"
-    Wwim::String = "g"
-    Ri::String = "#/d"
-    tL::Vector{String} = ["time since birth", "carapace length"]
-    psd::Any
-end
-units = units_struct(psd = psdUnits)
+bibkey = (
+    ab = "carettochelys",
+    ab30 = "carettochelys",
+    tp = "Spen2002",
+    tpm = "Spen2002",
+    am = "life span",
+    Lb = "Spen2002",
+    Lp = "Spen2002",
+    Lpm = "Spen2002",
+    Li = "Spen2002",
+    Lim = "Spen2002",
+    Wwb = "Spen2002",
+    Wwp = "Spen2002",
+    Wwpm = "Spen2002",
+    Wwi = "carettochelys",
+    Wwim = "carettochelys",
+    Ri = "Spen2002",
+    tL = "Spen2002",
+    F1 = "Wiki",
+)
 
-@with_kw mutable struct weight_struct
-    ab::Float64 = 1
-    ab30::Float64 = 1
-    tp::Float64 = 1
-    tpm::Float64 = 1
-    am::Float64 = 1
-    Lb::Float64 = 1
-    Lp::Float64 = 1
-    Lpm::Float64 = 1
-    Li::Float64 = 1
-    Lim::Float64 = 1
-    Wwb::Float64 = 1
-    Wwp::Float64 = 1
-    Wwpm::Float64 = 1
-    Wwi::Float64 = 1
-    Wwim::Float64 = 1
-    Ri::Float64 = 1
-    tL::Any
-    psd::Any
-end
+units = (
+    ab = "d",
+    ab30 = "d",
+    tp = "d",
+    tpm = "d",
+    am = "d",
+    Lb = "cm",
+    Lp = "cm",
+    Lpm = "cm",
+    Li = "cm",
+    Lim = "cm",
+    Wwb = "g",
+    Wwp = "g",
+    Wwpm = "g",
+    Wwi = "g",
+    Wwim = "g",
+    Ri = "#/d",
+    tL = ["time since birth", "carapace length"],
+    psd = psdUnits,
+)
+
 nvar = length(tL2)
 N = length(tL2[1])
-weights = weight_struct(tL = ones(N, nvar - 1) / N / (nvar - 1), psd = psdWeight)
 ## set weights for all real data
 #weights = setweights(data, weights);
-weights.tL = 2 * weights.tL;
+# weights.tL = 2 * weights.tL;
 
 ## set pseudodata and respective weights
 # [data, units, label, weights] = addpseudodata(data, units, label, weights);
-weights.psd.k_J = 0;
-weights.psd.k = 0.1;
+# weights.psd.k_J = 0;
+# weights.psd.k = 0.1;
+
+weights = (;
+    abg = 1,
+    ab30g = 1,
+    tpg = 1,
+    tpmg = 1,
+    amg = 1,
+    Lbg = 1,
+    Lpg = 1,
+    Lpmg = 1,
+    Lig = 1,
+    Limg = 1,
+    Wwbg = 1,
+    Wwpg = 1,
+    Wwpmg = 1,
+    Wwig = 1,
+    Wwimg = 1,
+    Rig = 1,
+    tL = ones(N, nvar - 1) / N / (nvar - 1),
+    psd = psdWeight,
+)
+
 data.psd.k = 0.3;
 units.psd.k = "-";
 label.psd.k = "maintenance ratio";
 
 # Discussion points
-@with_kw mutable struct discussion_struct
-    D1::String = "Males are assumed to differ from females by {p_Am} and E_Hb only" # Cat of Life
-end
-discussion = discussion_struct()
+discussion = (;
+    D1 = "Males are assumed to differ from females by {p_Am} and E_Hb only", # Cat of Life
+)
 
 # Facts
-@with_kw mutable struct facts_struct
-    F1::String = "Omnivorous"
-end
-facts = facts_struct()
+facts = (
+    F1= "Omnivorous"
+)
 
 # Links
-@with_kw mutable struct links_struct
-    id_CoL::String = "39LSX" # Cat of Life
-    id_ITIS::String = "949506" # ITIS
-    id_EoL::String = "794804" # Ency of Life
-    id_Wiki::String = "Emydura_macquarii" # Wikipedia
-    id_ADW::String = "Emydura_macquarii" # ADW
-    id_Taxo::String = "93062" # Taxonomicon
-    id_WoRMS::String = "1447999" # WoRMS
-    id_ReptileDB::String = "genus=Emydura&species=macquarii" # ReptileDB
-    id_AnAge::String = "Emydura_macquarii" # AnAge
-end
-links = links_struct()
+links = (; 
+    id_CoL = "39LSX", # Cat of Life
+    id_ITIS = "949506", # ITIS
+    id_EoL = "794804", # Ency of Life
+    id_Wiki = "Emydura_macquarii", # Wikipedia
+    id_ADW = "Emydura_macquarii", # ADW
+    id_Taxo = "93062", # Taxonomicon
+    id_WoRMS = "1447999", # WoRMS
+    id_ReptileDB = "genus=Emydura&species=macquarii", # ReptileDB
+    id_AnAge = "Emydura_macquarii", # AnAge
+)
 
-@with_kw mutable struct struct_comment
-    ab::String = "all temps are guessed"
-    ab30::String = ""
-    tp::String = ""
-    tpm::String = ""
-    am::String = ""
-    Lb::String = ""
-    Lp::String = ""
-    Lpm::String = ""
-    Li::String = ""
-    Lim::String = ""
-    Wwb::String = "based on (Lb/Li)^3*Wwi"
-    Wwp::String = "based on (Lp/Li)^3*Wwi"
-    Wwpm::String = "based on (Lpm/Li)^3*Ww"
-    Wwi::String = ""
-    Wwim::String = "based on (Lim/Li)^3*Wwi"
-    Ri::String = "#/d"
-    tL::Vector{String} = ["time since birth", "carapace length"]
-end
-comment = struct_comment()
+comment = (;
+    ab = "all temps are guessed",
+    ab30 = "",
+    tp = "",
+    tpm = "",
+    am = "",
+    Lb = "",
+    Lp = "",
+    Lpm = "",
+    Li = "",
+    Lim = "",
+    Wwb = "based on (Lb/Li)^3*Wwi",
+    Wwp = "based on (Lp/Li)^3*Wwi",
+    Wwpm = "based on (Lpm/Li)^3*Ww",
+    Wwi = "",
+    Wwim = "based on (Lim/Li)^3*Wwi",
+    Ri = "#/d",
+    tL = ["time since birth", "carapace length"],
+)
 
 # pack auxData and txtData for output
 
-@with_kw mutable struct struct_txtData{A,B,C,D}
-    units::A = units
-    label::B = label
-    bibkey::C = bibkey
-    comment::D = comment
-end
-txtData = struct_txtData()
+# TODO: move this somewhere shared if this is a common structure?
+# struct TxtData{A,B,C,D}
+#     units::A
+#     label::B
+#     bibkey::C
+#     comment::D
+# end
 
-@with_kw mutable struct struct_auxData{T}
-    temp::T = temp
-end
-auxData = struct_auxData()
+txtData = (; units, label, bibkey, comment)
+
+auxData = (;
+    temp = temp,
+)
 
 # ## References
 bibkey = "Wiki";
@@ -315,15 +308,9 @@ bib = "howpublished = {\\url{http://www.carettochelys.com/emydura/emydura_mac_ma
 carettochelys = "''@" * type * "{" * bibkey * ", " * join(bib) * "}'';";
 # metaData.biblist.(bibkey) = ["""@", type, "{", bibkey, ", " bib, "}"";"];
 
-@with_kw mutable struct biblist_struct
-    Kooy2010::String = Kooy2010
-    Spen2002::String = Spen2002
-    AnAge::String = AnAge
-    carettochelys::String = carettochelys
-end
-biblist = biblist_struct()
+biblist = [Kooy2010, Kooy2010, Spen2002, AnAge, carettochelys]
 
-metaData = metaData_struct(
+metaData = (;
     ecoCode = ecoCode,
     links = links,
     facts = facts,
@@ -332,10 +319,4 @@ metaData = metaData_struct(
     biblist = biblist,
 )
 
-# export(data)
-# export(auxData)
-# export(metaData)
-# export(txtData)
-# export(weights)
-# #(data, auxData, metaData, txtData, weights)
-# end
+(; data, auxData, metaData, txtData, weights)

--- a/example/pars_init_Emydura_macquarii.jl
+++ b/example/pars_init_Emydura_macquarii.jl
@@ -1,99 +1,99 @@
-Base.@kwdef struct Par{T,Z,L,K,V,PV,PS,R,EV,E,RR,S,D,DM,F,EM,N}
-    # reference parameter (not to be changed) 
-    T_ref::T = Param(20.0 + 273.15, units=u"K", free=(0), label="Reference Temperature")
+par = (;
+    # reference parameter (not to be changed),
+    T_ref = Param(20.0 + 273.15, units=u"K", free=(0), label="Reference Temperature"),
 
-    # core primary parameters 
-    z::N = Param(13.2002, units=nothing, free=(1), label="zoom factor")
-    F_m::L = Param(6.5, units=u"l/d/cm^2", free=(0), label="{F_m}, max spec searching rate")
-    kap_X::K = Param(0.8, units=nothing, free=(0), label="digestion efficiency of food to reserve")
-    kap_P::K = Param(0.1, units=nothing, free=(0), label="faecation efficiency of food to faeces")
-    v::V = Param(0.060464, units=u"cm/d", free=(1), label="energy conductance")
-    kap::K = Param(0.7362, units=nothing, free=(1), label="allocation fraction to soma")
-    kap_R::K = Param(0.95, units=nothing, free=(0), label="reproduction efficiency")
-    p_M::PV = Param(16.4025, units=u"J/d/cm^3", free=(1), label="[p_M], vol-spec somatic maint")
-    p_T::PS = Param(0.0, units=u"J/d/cm^2", free=(0), label="{p_T}, surf-spec somatic maint")
-    k_J::R = Param(0.00060219, units=u"1/d", free=(1), label="maturity maint rate coefficient")
-    E_G::EV = Param(7857.8605, units=u"J/cm^3", free=(1), label="[E_G], spec cost for structure")
-    E_Hb::E = Param(1.366e+04, units=u"J", free=(1), label="maturity at birth")
-    E_Hp::E = Param(1.168e+07, units=u"J", free=(1), label="maturity at puberty")
-    h_a::RR = Param(1.211e-09, units=u"1/d^2", free=(1), label="Weibull aging acceleration")
-    s_G::S = Param(0.0001, units=nothing, free=(0), label="Gompertz stress coefficient")
+    # core primary parameters
+    z = Param(13.2002, units=nothing, free=(1), label="zoom factor"),
+    F_m = Param(6.5, units=u"l/d/cm^2", free=(0), label="{F_m}, max spec searching rate"),
+    kap_X = Param(0.8, units=nothing, free=(0), label="digestion efficiency of food to reserve"),
+    kap_P = Param(0.1, units=nothing, free=(0), label="faecation efficiency of food to faeces"),
+    v = Param(0.060464, units=u"cm/d", free=(1), label="energy conductance"),
+    kap = Param(0.7362, units=nothing, free=(1), label="allocation fraction to soma"),
+    kap_R = Param(0.95, units=nothing, free=(0), label="reproduction efficiency"),
+    p_M = Param(16.4025, units=u"J/d/cm^3", free=(1), label="[p_M], vol-spec somatic maint"),
+    p_T = Param(0.0, units=u"J/d/cm^2", free=(0), label="{p_T}, surf-spec somatic maint"),
+    k_J = Param(0.00060219, units=u"1/d", free=(1), label="maturity maint rate coefficient"),
+    E_G = Param(7857.8605, units=u"J/cm^3", free=(1), label="[E_G], spec cost for structure"),
+    E_Hb = Param(1.366e+04, units=u"J", free=(1), label="maturity at birth"),
+    E_Hp = Param(1.168e+07, units=u"J", free=(1), label="maturity at puberty"),
+    h_a = Param(1.211e-09, units=u"1/d^2", free=(1), label="Weibull aging acceleration"),
+    s_G = Param(0.0001, units=nothing, free=(0), label="Gompertz stress coefficient"),
 
-    # other parameters 
-    E_Hpm::E = Param(4.711e+06, units=u"J", free=(1), label="maturity at puberty for male")
-    T_A::T = Param(8000.0, units=u"K", free=(0), label="Arrhenius temperature")
-    #T_AL::T = Param(50000.0, units=u"K", free=(0), label="low temp boundary")
-    #T_AH::T = Param(50000.0, units=u"K", free=(0), label="high temp boundary")
-    #T_L::T = Param(0 + 273.15, units=u"K", free=(0), label="low Arrhenius temperature")
-    #T_H::T = Param(54.5 + 273.15, units=u"K", free=(0), label="high Arrhenius temperature")
-    del_M::DM = Param(0.61719, units=nothing, free=(1), label="shape coefficient")
-    f::F = Param(1.0, units=nothing, free=(0), label="scaled functional response for 0-var data")
-    z_m::Z = Param(13.2002, units=u"cm", free=(1), label="zoom factor for male")
+    # other parameters
+    E_Hpm = Param(4.711e+06, units=u"J", free=(1), label="maturity at puberty for male"),
+    T_A = Param(8000.0, units=u"K", free=(0), label="Arrhenius temperature"),
+    #T_AL = Param(50000.0, units=u"K", free=(0), label="low temp boundary"),
+    #T_AH = Param(50000.0, units=u"K", free=(0), label="high temp boundary"),
+    #T_L = Param(0 + 273.15, units=u"K", free=(0), label="low Arrhenius temperature"),
+    #T_H = Param(54.5 + 273.15, units=u"K", free=(0), label="high Arrhenius temperature"),
+    del_M = Param(0.61719, units=nothing, free=(1), label="shape coefficient"),
+    f = Param(1.0, units=nothing, free=(0), label="scaled functional response for 0-var data"),
+    z_m = Param(13.2002, units=u"cm", free=(1), label="zoom factor for male"),
 
     # chemical parameters
     # specific densities; multiply free by d_V to convert to vector if necessary
-    d_X::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of food")
-    d_V::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of structure")
-    d_E::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of reserve")
-    d_P::D = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of faeces")
+    d_X = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of food"),
+    d_V = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of structure"),
+    d_E = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of reserve"),
+    d_P = Param(0.3, units=u"g/cm^3", free=(0), label="specific density of faeces"),
 
     # chemical potentials from Kooy2010 Tab 4.2
-    mu_X::EM = Param(525000.0, units=u"J/ mol", free=(0), label="chemical potential of food")
-    mu_V::EM = Param(500000.0, units=u"J/ mol", free=(0), label="chemical potential of structure")
-    mu_E::EM = Param(550000.0, units=u"J/ mol", free=(0), label="chemical potential of reserve")
-    mu_P::EM = Param(480000.0, units=u"J/ mol", free=(0), label="chemical potential of faeces")
+    mu_X = Param(525000.0, units=u"J/ mol", free=(0), label="chemical potential of food"),
+    mu_V = Param(500000.0, units=u"J/ mol", free=(0), label="chemical potential of structure"),
+    mu_E = Param(550000.0, units=u"J/ mol", free=(0), label="chemical potential of reserve"),
+    mu_P = Param(480000.0, units=u"J/ mol", free=(0), label="chemical potential of faeces"),
 
     # chemical potential of minerals
-    mu_C::EM = Param(0.0, units=u"J/ mol", free=(0), label="chemical potential of CO2")
-    mu_H::EM = Param(0.0, units=u"J/ mol", free=(0), label="chemical potential of H2O")
-    mu_O::EM = Param(0.0, units=u"J/ mol", free=(0), label="chemical potential of O2")
-    mu_N::EM = Param(4880.0, units=u"J/ mol", free=(0), label="chemical potential of N-waste")
+    mu_C = Param(0.0, units=u"J/ mol", free=(0), label="chemical potential of CO2"),
+    mu_H = Param(0.0, units=u"J/ mol", free=(0), label="chemical potential of H2O"),
+    mu_O = Param(0.0, units=u"J/ mol", free=(0), label="chemical potential of O2"),
+    mu_N = Param(4880.0, units=u"J/ mol", free=(0), label="chemical potential of N-waste"),
 
-    # chemical indices for water-free organics from Kooy2010 Fig 4.15 (excluding contributions of H and O atoms from water)
+    # chemical indices for water-free organics from Kooy2010 Fig 4.15 (excluding contributions of H and O atoms from water),
     # food
-    n_CX::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in food") # C/C = 1 by definition
-    n_HX::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in food")
-    n_OX::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in food")
-    n_NX::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in food")
+    n_CX = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in food"), # C/C = 1 by definition
+    n_HX = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in food"),
+    n_OX = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in food"),
+    n_NX = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in food"),
     # structure
-    n_CV::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in structure") # n_CV = 1 by definition
-    n_HV::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in structure")
-    n_OV::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in structure")
-    n_NV::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in structure")
+    n_CV = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in structure"), # n_CV = 1 by definition
+    n_HV = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in structure"),
+    n_OV = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in structure"),
+    n_NV = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in structure"),
     # reserve
-    n_CE::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in reserve")   # n_CE = 1 by definition
-    n_HE::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in reserve")
-    n_OE::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in reserve")
-    n_NE::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in reserve")
+    n_CE = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in reserve"),   # n_CE = 1 by definition
+    n_HE = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in reserve"),
+    n_OE = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in reserve"),
+    n_NE = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in reserve"),
     # faeces
-    n_CP::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in faeces")    # n_CP = 1 by definition
-    n_HP::N = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in faeces")
-    n_OP::N = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in faeces")
-    n_NP::N = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in faeces")
+    n_CP = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in faeces"),    # n_CP = 1 by definition
+    n_HP = Param(1.8, units=nothing, free=(0), label="chem. index of hydrogen in faeces"),
+    n_OP = Param(0.5, units=nothing, free=(0), label="chem. index of oxygen in faeces"),
+    n_NP = Param(0.15, units=nothing, free=(0), label="chem. index of nitrogen in faeces"),
 
-    # chemical indices for minerals from Kooy2010 
-    # CO2 
-    n_CC::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in CO2")
-    n_HC::N = Param(0.0, units=nothing, free=(0), label="chem. index of hydrogen in CO2")
-    n_OC::N = Param(2.0, units=nothing, free=(0), label="chem. index of oxygen in CO2")
-    n_NC::N = Param(0.0, units=nothing, free=(0), label="chem. index of nitrogen in CO2")
+    # chemical indices for minerals from Kooy2010
+    # CO2
+    n_CC = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in CO2"),
+    n_HC = Param(0.0, units=nothing, free=(0), label="chem. index of hydrogen in CO2"),
+    n_OC = Param(2.0, units=nothing, free=(0), label="chem. index of oxygen in CO2"),
+    n_NC = Param(0.0, units=nothing, free=(0), label="chem. index of nitrogen in CO2"),
     # H2O
-    n_CH::N = Param(0.0, units=nothing, free=(0), label="chem. index of carbon in H2O")
-    n_HH::N = Param(2.0, units=nothing, free=(0), label="chem. index of hydrogen in H2O")
-    n_OH::N = Param(1.0, units=nothing, free=(0), label="chem. index of oxygen in H2O")
-    n_NH::N = Param(0.0, units=nothing, free=(0), label="chem. index of nitrogen in H2O")
+    n_CH = Param(0.0, units=nothing, free=(0), label="chem. index of carbon in H2O"),
+    n_HH = Param(2.0, units=nothing, free=(0), label="chem. index of hydrogen in H2O"),
+    n_OH = Param(1.0, units=nothing, free=(0), label="chem. index of oxygen in H2O"),
+    n_NH = Param(0.0, units=nothing, free=(0), label="chem. index of nitrogen in H2O"),
     # O2
-    n_CO::N = Param(0.0, units=nothing, free=(0), label="chem. index of carbon in O2")
-    n_HO::N = Param(0.0, units=nothing, free=(0), label="chem. index of hydrogen in O2")
-    n_OO::N = Param(2.0, units=nothing, free=(0), label="chem. index of oxygen in O2")
-    n_NO::N = Param(0.0, units=nothing, free=(0), label="chem. index of nitrogen in O2")
+    n_CO = Param(0.0, units=nothing, free=(0), label="chem. index of carbon in O2"),
+    n_HO = Param(0.0, units=nothing, free=(0), label="chem. index of hydrogen in O2"),
+    n_OO = Param(2.0, units=nothing, free=(0), label="chem. index of oxygen in O2"),
+    n_NO = Param(0.0, units=nothing, free=(0), label="chem. index of nitrogen in O2"),
     # N-waste; multiply free by par to convert to vector if necessary
-    n_CN::N = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in N-waste")   # n_CN = 0 or 1 by definition
-    n_HN::N = Param(0.8, units=nothing, free=(0), label="chem. index of hydrogen in N-waste")
-    n_ON::N = Param(0.6, units=nothing, free=(0), label="chem. index of oxygen in N-waste")
-    n_NN::N = Param(0.8, units=nothing, free=(0), label="chem. index of nitrogen in N-waste")
-end
-@with_kw mutable struct metaPar_struct
-    model = "std"
-end
-metaPar = metaPar_struct()
+    n_CN = Param(1.0, units=nothing, free=(0), label="chem. index of carbon in N-waste"),   # n_CN = 0 or 1 by definition
+    n_HN = Param(0.8, units=nothing, free=(0), label="chem. index of hydrogen in N-waste"),
+    n_ON = Param(0.6, units=nothing, free=(0), label="chem. index of oxygen in N-waste"),
+    n_NN = Param(0.8, units=nothing, free=(0), label="chem. index of nitrogen in N-waste"),
+)
+
+metapar = (; model = "std")
+
+(; par, metapar)

--- a/example/predict_Emydura_macquarii.jl
+++ b/example/predict_Emydura_macquarii.jl
@@ -1,12 +1,12 @@
 function predict_Emydura_macquarii(par, data, auxData)# predict
     cPar = parscomp_st(par)
-    @unpack T_ref, T_A, del_M, f, kap, kap_R, v, k_J, h_a, s_G, p_M, z_m, E_G = par
-    @unpack k, l_T, v_Hb, v_Hp, L_m, w, k_M, w, L_T, U_Hb, U_Hp, w_E, w_V, y_E_V, v_Hpm = cPar 
-    @unpack temp = auxData
-    @unpack Lb, Li, Lim, Lp, Lpm, Ri, Wwb, Wwi, Wwim, Wwp, Wwpm, ab, ab30, am, psd, tL, tp, tpm = data
-    @unpack E_V, J_E_M, M_Hb, U_Hb, V_Hp, eta_VG, j_E_J, k_M, m_Em, ome, s_H, v_Hb, w_E, w_X, y_P_E, y_X_E,
+    (; T_ref, T_A, del_M, f, kap, kap_R, v, k_J, h_a, s_G, p_M, z_m, E_G) = par
+    (; k, l_T, v_Hb, v_Hp, L_m, w, k_M, w, L_T, U_Hb, U_Hp, w_E, w_V, y_E_V, v_Hpm) = cPar 
+    (; temp) = auxData
+    (; Lb, Li, Lim, Lp, Lpm, Ri, Wwb, Wwi, Wwim, Wwp, Wwpm, ab, ab30, am, psd, tL, tp, tpm) = data
+    (; E_V, J_E_M, M_Hb, U_Hb, V_Hp, eta_VG, j_E_J, k_M, m_Em, ome, s_H, v_Hb, w_E, w_X, y_P_E, y_X_E,
     E_m, J_E_T, L_T, M_Hp, U_Hp, eta_O, eta_XA, j_E_M, kap_G, n_M, p_Am, u_Hb, v_Hp, w_P, y_E_V, y_P_X, y_X_P,
-    J_E_Am, J_X_Am, L_m, M_V, V_Hb, eta_PA, k, l_T, n_O, p_Xm, u_Hp, w, w_V, y_E_X, y_V_E = cPar
+    J_E_Am, J_X_Am, L_m, M_V, V_Hb, eta_PA, k, l_T, n_O, p_Xm, u_Hp, w, w_V, y_E_X, y_V_E) = cPar
     g2 = cPar.g
     # compute temperature correction factors
     TC = tempcorr(temp.am, T_ref, T_A);

--- a/example/run_Emydura_macquarii.jl
+++ b/example/run_Emydura_macquarii.jl
@@ -1,12 +1,17 @@
 using DEBtool_J
-using Parameters
 using ModelParameters
 using Unitful
 
+srcpath = dirname(pathof(DEBtool_J))
+examplepath = realpath(joinpath(srcpath, "../example"))
+
 pets = ["Emydura_macquarii"];
 #include("predict_Emydura_macquarii.jl")
-include("pars_init_" * pets[1] * ".jl")
-par_model = Model(Par()) # create a 'Model' out of the Pars struct
+(; par, metapar) = let # Let block so we only import the last variable into scope
+    include(joinpath(examplepath, "pars_init_" * pets[1] * ".jl"))
+end
+par_model = Model(par) # create a 'Model' out of the Pars struct
+data_pets = mydata_pets(pets, examplepath)
 
 #check_my_pet(pets); 
 estim_options("default");
@@ -18,4 +23,4 @@ estim_options("results_output", 3);
 estim_options("method", "nm");
 
 # currently takes 55 seconds to do 500 steps, matlab takes just under 40
-estim_pars(pets, par_model, metaPar)
+estim_pars(pets, par_model, metapar, data)

--- a/src/DEBtool_J.jl
+++ b/src/DEBtool_J.jl
@@ -8,7 +8,7 @@ using Statistics
 using Random
 using SpecialFunctions
 using QuadGK
-using OrdinaryDiffEq
+using DiffEqBase
 
 abstract type AbstractDEBModel end
 

--- a/src/lib/pet/estim_pars.jl
+++ b/src/lib/pet/estim_pars.jl
@@ -3,7 +3,7 @@
 
 ##
 #function estim_pars(pets, pars_init_method, method, filter, covRules)
-function estim_pars(pets = ["Emydura_macquarii"], par_model = par_model, metaPar = metaPar)
+function estim_pars(pets, par_model, metaPar, mydata_pets)
 
     # created 2015/02/10 by Goncalo Marques
     # modified 2015/02/10 by Bas Kooijman, 
@@ -45,14 +45,10 @@ function estim_pars(pets = ["Emydura_macquarii"], par_model = par_model, metaPar
     global pets, pars_init_method, method, filter, covRules
     global parPets, par
 
-    global pets = ["Emydura_macquarii"]
-    include("predict_Emydura_macquarii.jl")
-
     n_pets = length(pets)
 
     # get data
-    #[data, auxData, metaData, txtData, weights] = mydata_pets;
-    data, auxData, metaData, txtData, weights = mydata_pets(pets)
+    data, auxData, metaData, txtData, weights = mydata_pets
 
     if n_pets == 1
         pars_initnm = "pars_init_" * pets[1]

--- a/src/lib/pet/mydata_pets.jl
+++ b/src/lib/pet/mydata_pets.jl
@@ -3,7 +3,7 @@
 
 ##
 #function [data, auxData, metaData, txtData, weights] = mydata_pets
-function mydata_pets(pets)
+function mydata_pets(pets, srcpath)
     # created by Goncalo Marques at 2015/01/28, modified Bas Kooijman 2021/01/17
 
     ## Syntax
@@ -20,7 +20,7 @@ function mydata_pets(pets)
     # * metaData: catenated metadata structure
     # * weights: catenated weights structure
 
-    global pets, pseudodata_pets, petnm
+    # global pets, pseudodata_pets, petnm
     #  ["mydata_" * x for x in pets]
     #  function load_modules(module_names::Vector{String})
     #   for name in module_names
@@ -44,49 +44,10 @@ function mydata_pets(pets)
     #   #@get_mydata_pets(pets[i])
     # end  
 
-    i = 0
-    for file_name in ["c:/git/DEBtool_J.jl/example/mydata_" * x * ".jl" for x in pets]
-        i = i + 1
-        include(file_name) # load the mydata file
-
-        # stuff the results into new objects of style e.g. data.mypet.etc, auxData.mypet.etc
-        # TO DO - simplify this!
-        petnm = Symbol(pets[i])
-        eval(:($petnm = data))
-        @eval begin
-            struct data_struct2
-                $petnm
-            end
-            data = data_struct2($petnm)
-        end
-        eval(:($petnm = auxData))
-        @eval begin
-            struct auxData_struct2
-                $petnm
-            end
-            auxData = auxData_struct2($petnm)
-        end
-        eval(:($petnm = metaData))
-        @eval begin
-            struct metaData_struct2
-                $petnm
-            end
-            metaData = metaData_struct2($petnm)
-        end
-        eval(:($petnm = txtData))
-        @eval begin
-            struct txtData_struct2
-                $petnm
-            end
-            txtData = txtData_struct2($petnm)
-        end
-        eval(:($petnm = weights))
-        @eval begin
-            struct weights_struct2
-                $petnm
-            end
-            weights = weights_struct2($petnm)
-        end
+    # TODO combine these somehow when there are multiple pets
+    local data
+    for file_name in (joinpath(srcpath, "mydata_" * pet * ".jl") for pet in pets)
+        data = include(file_name) # load the mydata file
     end
 
     #[data.(pets{i}), auxData.(pets{i}), metaData.(pets{i}), txtData.(pets{i}), weights.(pets{i})] = feval(['mydata_', pets{i}]);
@@ -109,5 +70,5 @@ function mydata_pets(pets)
     #   weights.psd = weightsG.psd;
     #   txtData.psd.units = unitsG.psd;
     #   txtData.psd.label = labelG.psd;
-    return (data, auxData, metaData, txtData, weights)
+    return (; data, auxData, metaData, txtData, weights)
 end

--- a/src/lib/pet/parscomp_st.jl
+++ b/src/lib/pet/parscomp_st.jl
@@ -61,7 +61,8 @@ function parscomp_st(p)
     else
         p_Am = p.p_Am
     end
-    global cPar = (; p_Am)
+
+    cPar = (; p_Am)
 
     #         X       V       E       P
     n_O =


### PR DESCRIPTION
@mrke this is my idea for simplifying pet definitions

Using `NamedTuple` is much leaner than defining structs for everything, and removes some `eval`

(But there is something not quite working now in `parscomp_st`, some field is missing.)