### PR TITLE
use BiophysicalEcologyBase.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Rafael Schouten", "Bas Kooijman, Goncalo Marques, Starrlight Augusti
 version = "0.1.0"
 
 [deps]
+BiophysicalEcologyBase = "2ffd7b4c-1bc0-4ac6-9c6c-64838726cb7f"
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
@@ -28,6 +29,7 @@ DEBtool_JMakieExt = "Makie"
 [compat]
 julia = "1.11"
 Aqua = "0.8"
+BiophysicalEcologyBase = "0.1"
 ComponentArrays = "0.15.28"
 DataInterpolations = "8"
 DelimitedFiles = "1.9.1"
@@ -53,6 +55,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
 ModelParameters = {url = "https://github.com/rafaqz/ModelParameters.jl", rev = "consts"}
+BiophysicalEcologyBase = {url = "https://github.com/BiophysicalEcology/BiophysicalEcologyBase.jl", rev = "main"}
 
 [targets]
 test = ["Aqua", "MAT", "Makie", "Test"]

--- a/src/DEBtool_J.jl
+++ b/src/DEBtool_J.jl
@@ -1,5 +1,6 @@
 module DEBtool_J
 
+using BiophysicalEcologyBase
 using ModelParameters
 using Unitful
 using Unitful: °C, K, d, g, cm, mol, J

--- a/src/simulation/behavior.jl
+++ b/src/simulation/behavior.jl
@@ -1,19 +1,4 @@
 """
-    AbstractBehavior
-
-Abstract supertype for organism behaviors.
-
-Behaviors respond to physiological state and external stimuli,
-to either control *exposure* to the external stimuli, or modify
-physiological parameters to change the *effect* of the external stimuli.
-
-- Response to environmental information that leads to:
-    - Changes in metabolic parameters
-    - Changes in the environment or position within the environment
-"""
-abstract type AbstractBehavior end
-
-"""
     AbstractMovementBehavior
 
 Abstract supertype behaviors that modify location based

--- a/src/simulation/environment.jl
+++ b/src/simulation/environment.jl
@@ -1,5 +1,3 @@
-abstract type AbstractEnvironment end
-
 """
     ConstantEnvironment <: AbstractEnvironment
 


### PR DESCRIPTION
BiophysicalEcologyBase is an attempt to provide shared abstract types for julia software that relates to organisms living in environments (in the simplest cases these can be fixed temperatures and food availability).

Currently this PR deletes the local `AbstractEnvironment` and `AbstractBehavior` so they use the BiophysicalEcologyBase.jl types instead.

But putting this together I realised that our current `AbstractDEBOrganism` combines `AbstractPhysiology` and `AbstractMorphology` , so should use BiophysicalEcolgyBase via object composition rather than inheritance. This split continues into DEB model types - std/hex/abj etc mix pysiological and morphological differences. 

And actually morphology and physiology changes per lifestage. The `AbstractLifeStage` here already has `AbstractMorph` and `AbstractFeeding` as type parameters so it is the object where we use composition of BiophysicalEcololgyBase.jl types.

@mkre this is interesting for the theory how these components interact, and technically how these tools will fit together. Morphology and physiology will have to be per-lifestage everywhere for packages to work together. Probably animal lifestages are not really core DEB theory and should end up in another package aimed at orchestrating these temporal changes in physiology and morphology.